### PR TITLE
Update to support modern ffmpeg APIs (v5+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@
 *.exe
 *.out
 *.app
+
+# Other
+*.mp4
+*.flim
+flimutil
+flimmaker
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Alternatively, you can build it from the source code, by downloading the 'MacFli
 
 The pre-requisites are ffmpeg, youtube-dl or yt-dlp (optional) and ImageMagick (optional)
 
-* ``ffmpeg`` and associated libraries are required for compilation (version 7.0.2 or higher is recommended).
+* ``ffmpeg`` and associated libraries are required for compilation (version 7 or higher is recommended, but version 5 or higher should work).
 * ``yt-dlp`` or ``youtube-dl`` is used if you want to directly encode movies from youtube or vimeo (or others).
 * ``ImageMagick`` is used if you want to generate ``gif`` files.
 
@@ -82,7 +82,7 @@ You can the get the source code using:
 
 (or your regional equivalent)
 
-Compiling is as simple as opening a terminal and typing ``make`` (see notes for Apple silicon below). There are some warnings of obsolete functions use with ffmpeg, but it is already a miracle that it works. If anyone has a pull request to fix this, let me know.
+Compiling is as simple as opening a terminal and typing ``make`` (see notes for Apple silicon below). There may be some warnings of obsolete functions use with ffmpeg, but it is already a miracle that it works. If anyone has a pull request to fix this, let me know.
 
 After compilation, you can generate a sample flim using:
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,13 @@ Alternatively, you can build it from the source code, by downloading the 'MacFli
 
 The pre-requisites are ffmpeg, youtube-dl or yt-dlp (optional) and ImageMagick (optional)
 
-* ``ffmpeg`` libraries are required for compilation (you'll need version 4.x).
+* ``ffmpeg`` and associated libraries are required for compilation (version 7.0.2 or higher is recommended).
 * ``yt-dlp`` or ``youtube-dl`` is used if you want to directly encode movies from youtube or vimeo (or others).
 * ``ImageMagick`` is used if you want to generate ``gif`` files.
 
 On a Mac:
 
-    brew unlink ffmpeg
-    brew install ffmpeg@4
-    brew link ffmpeg@4
+    brew install ffmpeg
     brew install yt-dlp
     brew install ImageMagick
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ flimmaker.o: flimmaker.cpp flimencoder.hpp flimcompressor.hpp compressor.hpp img
 	c++ $(LDLIBS) -std=c++2a flimmaker.o imgcompress.o image.o watermark.o ruler.o reader.o writer.o -lavformat -lavcodec -lavutil -o ../flimmaker
 
 ../flimutil: flimutil.c
-	cc -O3 -Wno-unused-result  flimutil.c -o ../flimutil
+	cc -O3 -Wno-unused-result flimutil.c -o ../flimutil
 
 clean:
 	rm -f ../flimmaker ../flimutil flimmaker.o imgcompress.o image.o watermark.o ruler.o reader.o writer.o
@@ -47,10 +47,6 @@ debug: flimmaker.cpp flimutil.c imgcompress.cpp watermark.cpp image.cpp ruler.cp
 	c++ -O0 -std=c++2a -c -g -fsanitize=undefined writer.cpp -o writer.o
 	c++ -O0 -std=c++2a -g -fsanitize=undefined imgcompress.o flimmaker.o watermark.o image.o ruler.o reader.o writer.o -lavformat -lavcodec -lavutil -o ../flimmaker
 	cc -g -Wno-unused-result flimutil.c -o ../flimutil
-#	gdb ./flimmaker
 
 video_test: video_test.c
 	gcc -Wno-deprecated-declarations video_test.c -lavformat -lavcodec -lavutil -o video_test
-
-
-#../flimmaker --input '/media/fred/Movies/Movies/Collections/Star Wars (1977-2019)/Star Wars - Episode V - The Empire Strikes Back (1980) [88]/Star Wars - Episode V - The Empire Strikes Back (1980) [720p,x264].mp4' --from 1:59:17.36 --duration 3.46 --bars false --group false --byterate 100000

--- a/src/flimencoder.hpp
+++ b/src/flimencoder.hpp
@@ -446,7 +446,7 @@ public:
         image poster_image = images_[0];
         size_t poster_index = poster_ts_*fps_/profile_.fps_ratio();
 
-        if (poster_index>=0 && poster_index<images_.size())
+        if (poster_index < images_.size())
             poster_image = images_[poster_index];
 
 std::cout << "POSTER INDEX: " << poster_index << "\n";

--- a/src/flimmaker.cpp
+++ b/src/flimmaker.cpp
@@ -30,108 +30,90 @@
 #include <vector>
 #include <array>
 #include <memory>
+#include <filesystem>
+#include <signal.h>
+#include <execinfo.h>
 #define noLZG
 #ifdef LZG
 #include "lzg.h"
 #endif
 #include "flimencoder.hpp"
-#include <filesystem>
 
 using namespace std::string_literals;
 
-//  True if the global '-g' option was set
+// True if the global '-g' option was set
 bool sDebug = false;
 
-//  If defined, we add a "stamp" to each stream, to know where it is coming from
+// If defined, we add a "stamp" to each stream, to know where it is coming from
 #define noSTAMP
 
 #ifdef STAMP
 static int sStream = 0;
 #endif
 
-
-
 #include "image.hpp"
 #include "reader.hpp"
 #include "writer.hpp"
 #include "subtitles.hpp"
 
-inline bool ends_with(std::string const & value, std::string const & ending)
-{
+inline bool ends_with(std::string const & value, std::string const & ending) {
     if (ending.size() > value.size()) return false;
     return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-int num_from_string( const char **s )
-{
+int num_from_string(const char **s) {
     int n = 0;
-    while (**s>='0' && **s<='9')
-    {
-        n = n*10 + (**s-'0');
+    while (**s >= '0' && **s <= '9') {
+        n = n * 10 + (**s - '0');
         (*s)++;
     }
-
     return n;
 }
 
-//  Converts a timestamp into a second count
-//  42 => 42
-//  05:31 => 331
-//  2:4 => 124
-//  02:04.470 => 124.47
-//  1230.2 => 1230.2
-//  0001:1:1:3.1toto => 219663.1
-double seconds_from_string( const char *s )
-{
+// Converts a timestamp into a second count
+// 42 => 42
+// 05:31 => 331
+// 2:4 => 124
+// 02:04.470 => 124.47
+// 1230.2 => 1230.2
+// 0001:1:1:3.1toto => 219663.1
+double seconds_from_string(const char *s) {
     double d = 0;
-
-    for (;;)
-    {
-        if (*s>='0' && *s<='9')
-            d = d*60 + num_from_string( &s );
-        if (*s!=':')
+    for (;;) {
+        if (*s >= '0' && *s <= '9')
+            d = d * 60 + num_from_string(&s);
+        if (*s != ':')
             break;
         s++;
     }
-
     if (!*s)
         return d;
-    
-    if (*s=='.')
-    {
+    if (*s == '.') {
         double f = 1;
         s++;
-        while (*s>='0' && *s<='9')
-        {
+        while (*s >= '0' && *s <= '9') {
             f /= 10;
-            d += f*(*s++-'0');
+            d += f * (*s++ - '0');
         }
     }
-
     return d;
 }
 
-void test_seconds_from_string()
-{
-    assert( seconds_from_string( "42" ) == 42 );
-    assert( seconds_from_string( "05:31" ) == 331 );
-    assert( seconds_from_string( "2:4" ) == 124 );
-    assert( seconds_from_string( "02:04.470" ) == 124.47 );
-    assert( seconds_from_string( "1230.2" ) == 1230.2 );
-    assert( seconds_from_string( "0001:1:1:3.1toto" ) == 219663.1 );
+void test_seconds_from_string() {
+    assert(seconds_from_string("42") == 42);
+    assert(seconds_from_string("05:31") == 331);
+    assert(seconds_from_string("2:4") == 124);
+    assert(seconds_from_string("02:04.470") == 124.47);
+    assert(seconds_from_string("1230.2") == 1230.2);
+    assert(seconds_from_string("0001:1:1:3.1toto") == 219663.1);
 }
 
-//  Write a bunch of bytes in a file
-void write_data( const char *file, u_int8_t *data, size_t len )
-{
-    // fprintf( stderr, "Writing [%s]\n", file );
-
-    FILE *f = fopen( file, "wb" );
-
+// Write a bunch of bytes in a file
+void write_data(const char *file, u_int8_t *data, size_t len) {
+    FILE *f = fopen(file, "wb");
     while (len--)
-        fputc( *data++, f );
-
-    fclose( f );
+        fputc(*data++, f);
+    fclose(f);
 }
 
 const char *version = "2.0.0";
@@ -140,16 +122,12 @@ const char *version = "2.0.0";
 #include <chrono>
 #include <ctime>
 
-void usage( const std::string name )
-{
+void usage(const std::string name) {
     std::cerr << "Usage\n";
-
     std::cerr << name << " INPUT [OPTIONS ...]\n";
-
     std::cerr << "  INPUT can be either a mp4 file name, a movie URL or a 'pgm' pattern.'\n";
 
     std::cerr << "\n  Input options:\n";
-
     std::cerr << "    --from TIME                 : time offset to start extracting from\n";
     std::cerr << "    --duration TIME             : time duration of the extracted clip\n";
     std::cerr << "    --poster TIME               : frame to extract the poster from (by default 1/3 of duration)ß\n";
@@ -158,566 +136,427 @@ void usage( const std::string name )
     std::cerr << "    --srt FILE                  : burns the subtitle file into the flim\n";
 
     std::cerr << "\n  Output options:\n";
-
     std::cerr << "    --flim FILE                 : name of the flim file to create (by default 'out.flim')\n";
     std::cerr << "    --mp4 FILE                  : outputs a 60fps mp4 file with the result\n";
     std::cerr << "    --gif FILE                  : outputs a 20fps gif file with the result\n";
     std::cerr << "    --pgm PATTERN               : output every generated image in a pgm file\n";
 
     std::cerr << "\n  Encoding options:\n";
-
     std::cerr << "    --profile PROFILE           : presents the specific encoding profile, which sets a suitable default for all encoding options\n";
     std::cerr << "      Default is 'se30'. See below for description of profiles.\n";
-
     std::cerr << "    --silent BOOLEAN            : set to true for silent flims\n";
-
     std::cerr << "    --byterate BYTERATE         : bytes per ticks available for video compression\n";
     std::cerr << "    --fps-ratio BOOLEAN         : ratio of images from the source to drop.\n";
     std::cerr << "    --group BOOLEAN             : if true, packs ticks together to present screen updates at the same rate as the input media. Only works on a se30.\n";
-
     std::cerr << "    --bars BOOLEAN              : if false, image is zoomed in so there are no black bars.\n";
-
     std::cerr << "    --dither DITHER             : specifies the type of dithering to be used.\n";
     std::cerr << "      'ordered' will use a 4x4 ordered dither matrix.\n";
     std::cerr << "      'error' will use an error diffusion algorithm.\n";
     std::cerr << "    --error-algorithm ALGORITHM : error diffusion algorithm to be used\n";
     std::cerr << "      Default 'floyd'. See below for the list of valid error dithering algorithms.\n";
-
     std::cerr << "    --error-stability FLOAT     : amount of error to be accumulated before changing a screen pixel\n";
     std::cerr << "    --error-bidi BOOLEAN        : if true, error diffusion is applied in different direction for even and odd scanlines.\n";
     std::cerr << "    --error-bleed PERCENT       : how much error is moved from a pixel to the neighbours.\n";
-
     std::cerr << "    --filters FILTERS           : specifies a set of filters to be applied on image afgter resizing, but before dithering\n";
     std::cerr << "    --codec CODEC               : adds a specific codec to the encoding. The first --codec parameter clears the profile codec list\n";
 
     std::cerr << "\n  Misc options:\n";
-
     std::cerr << "    --watermark STRING          : adds the string to the upper left corner of the generated flim for identification purposes.\n";
     std::cerr << "      use 'auto' to use the encoding parameters as watermark\n";
-
     std::cerr << "    --debug BOOLEAN             : enables various debug options\n";
 
-        // else if (!strcmp(*argv,"--cover-from"))
-        // else if (!strcmp(*argv,"--cover-to"))
-        // else if (!strcmp(*argv,"--cover"))
-        // else if (!strcmp(*argv,"--diff-pattern"))
-        // else if (!strcmp(*argv,"--change-pattern"))
-        // else if (!strcmp(*argv,"--target-pattern"))
-        // else if (!strcmp(*argv,"--comment"))
-
     std::cerr << "\nList of profiles names for the --profile option (default 'se30'):\n";
-    for (auto n:{ "128k", "512k", "xl", "plus", "se", "portable", "se30", "perfect" })
-    {
+    for (auto n : { "128k", "512k", "xl", "plus", "se", "portable", "se30", "perfect" }) {
         encoding_profile p;
-        encoding_profile::profile_named( n, 512, 342, p );
+        encoding_profile::profile_named(n, 512, 342, p);
         std::cerr << "        " << n << " : " << p.description() << "\n";
     }
 
     std::cerr << "\nList of error diffusion algorithms for the --error_diffusion option (default 'floyd'):\n";
 
-    error_diffusion_algorithms( []( const std::string name, const std::string description )
-    {
-        fprintf( stderr, "               %16s : %s\n", name.c_str(), description.c_str() );
-    } );
-
+    error_diffusion_algorithms([](const std::string name, const std::string description) {
+        fprintf(stderr, "               %16s : %s\n", name.c_str(), description.c_str());
+    });
 
     std::cerr << "use '" << name << " --help' for displaying this help page.\n";
 }
 
-//  The main function, does all the work
-//  flimmaker [-g] --in <%d.pgm> --from <index> --to <index> --cover <index> --audio <audio.waw> --flim <file>
-int main( int argc, char **argv )
-{
-try
-{
-    // std::string in_arg = "movie-%06d.pgm";
-    std::string input_file = "";
-    std::string srt_file = "";
-    std::string mp4_file = "";
-    std::string gif_file = "";
-    std::string out_arg = "out.flim";
-    std::string audio_arg = "audio.raw";
-    double from_index = 0;  //  #### This is not an index, it is a timestamp
-    double to_index = std::numeric_limits<double>::max();
-    double duration = 300;   //  5 minutes by default
-    double poster_ts = -1;
-    int cover_from = -1;
-    int cover_to = -1;
-    double fps = 24.0;
-    std::string watermark = "";
-    std::string pgm_pattern = ""; // "out-%06d.pgm";
-    std::string diff_pattern = "";
-    std::string change_pattern = "";
-    std::string target_pattern = "";
-    bool auto_watermark = false;
-    std::string cache_file = std::tmpnam( nullptr );
-    bool generated_cache = true;
-    bool downloaded_file = false;
+void segfault_handler(int signal) {
+    void *array[10];
+    size_t size;
 
-    bool profile_set = false;
+    // get void*'s for all entries on the stack
+    size = backtrace(array, 10);
 
-    const std::string cmd_name{ argv[0] };
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d:\n", signal);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+    exit(1);
+}
 
-    // test_ffmpeg( argv[1] );
+// The main function, does all the work
+// flimmaker [-g] --in <%d.pgm> --from <index> --to <index> --cover <index> --audio <audio.wav> --flim <file>
+int main(int argc, char **argv) {
+    signal(SIGSEGV, segfault_handler);
+    try {
+        std::string input_file = "";
+        std::string srt_file = "";
+        std::string mp4_file = "";
+        std::string gif_file = "";
+        std::string out_arg = "out.flim";
+        std::string audio_arg = "audio.raw";
+        double from_index = 0;  // #### This is not an index, it is a timestamp
+        double to_index = std::numeric_limits<double>::max();
+        double duration = 300;  // 5 minutes by default
+        double poster_ts = -1;
+        int cover_from = -1;
+        int cover_to = -1;
+        double fps = 24.0;
+        std::string watermark = "";
+        std::string pgm_pattern = ""; // "out-%06d.pgm";
+        std::string diff_pattern = "";
+        std::string change_pattern = "";
+        std::string target_pattern = "";
+        bool auto_watermark = false;
+        std::string cache_file = std::tmpnam(nullptr);
+        bool generated_cache = true;
+        bool downloaded_file = false;
+        bool profile_set = false;
 
-    std::vector<flimcompressor::codec_spec> codecs;
+        const std::string cmd_name{ argv[0] };
 
-    codecs.push_back( {} );
-    codecs.back().signature = 0x00;
-    codecs.back().penality = 1;
-    codecs.back().coder = std::make_shared<null_compressor>( 0, 0 );    //  Unsure if this makes sense any more.
+        // test_ffmpeg(argv[1]);
 
-    std::string comment = "FLIM\n";
-    
-    for (int i=0;i!=argc;i++)
-    {
-        if (i!=0)
-            comment += " ";
-        comment += argv[i];
-    }
+        std::vector<flimcompressor::codec_spec> codecs;
+        codecs.push_back({});
+        codecs.back().signature = 0x00;
+        codecs.back().penality = 1;
+        codecs.back().coder = std::make_shared<null_compressor>(0, 0);
 
-    comment += "\n";
-    comment += "flimmaker-version: ";
-    comment += version;
-    comment += "\n";
+        std::string comment = "FLIM\n";
+        for (int i = 0; i != argc; i++) {
+            if (i != 0)
+                comment += " ";
+            comment += argv[i];
+        }
+        comment += "\nflimmaker-version: ";
+        comment += version;
+        comment += "\n";
 
-size_t width = 512;
-size_t height = 342;
-std::string profile_name = "se30";
+        size_t width = 512;
+        size_t height = 342;
+        std::string profile_name = "se30";
 
-    encoding_profile custom_profile;
-    if (!encoding_profile::profile_named( profile_name, width, height, custom_profile ))
-    {
-        std::cerr << "Cannot find default profile '"<< profile_name << "'\n";
-        ::exit( EXIT_FAILURE );
-    }
-
-    // std::time_t time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    // comment += "date: ";
-    // comment += std::ctime(&time);
-
-    // packz32_test();
-    packz32opt_test();
-    test_seconds_from_string();
-
-    argc--;
-    argv++;
-
-    while (argc)
-    {
-        if (!strcmp(*argv,"--help"))
-        {
-            usage( cmd_name );
-            ::exit( EXIT_SUCCESS );
+        encoding_profile custom_profile;
+        if (!encoding_profile::profile_named(profile_name, width, height, custom_profile)) {
+            std::cerr << "Cannot find default profile '" << profile_name << "'\n";
+            ::exit(EXIT_FAILURE);
         }
 
-        // if (!strcmp(*argv,"--input"))
-        //  Doesn't start with '--', this is the input file/url
-        if (strncmp(*argv,"--",2))
-        {
-            if (input_file!="")
-            {
-                std::cerr << "Input file specified twice: '" << input_file << "' and '" << *argv << "'\n";
-                ::exit( EXIT_FAILURE );
-            }
-            input_file = *argv;
-        }
-        else if (!strcmp(*argv,"--cache"))
-        {
-            argc--;
-            argv++;
-            cache_file = *argv;
-            generated_cache = false;
-        }
-        else if (!strcmp(*argv,"--mp4"))
-        {
-            argc--;
-            argv++;
-            mp4_file = *argv;
-        }
-        else if (!strcmp(*argv,"--srt"))
-        {
-            argc--;
-            argv++;
-            srt_file = *argv;
-        }
-        else if (!strcmp(*argv,"--gif"))
-        {
-            argc--;
-            argv++;
-            gif_file = *argv;
-        }
-        else if (!strcmp(*argv,"--profile"))
-        {
-            argc--;
-            argv++;
-            profile_name = *argv;
-            if (profile_name=="xl") //  ####KLUDGE!
-            {
-                width = (720/32)*32;
-                height = 364;
-                std::cerr << "xl -- setting resolution to " << width << "x" << height << "\n";
-            }
-            if (profile_name=="portable")
-            {
-                width = (640/32)*32;
-                height = 400;
-                std::cerr << "portable -- setting resolution to " << width << "x" << height << "\n";
-            }
-            if (!encoding_profile::profile_named( profile_name, width, height, custom_profile ))
-            {
-                std::cerr << "Cannot find encoding profile '" << *argv << "'\n";
-                ::exit( EXIT_FAILURE );
-            }
-            profile_set = true;
-        }
-        else if (!strcmp(*argv,"--width"))
-        {
-            argc--;
-            argv++;
-            if (profile_set)
-            {
-                std::cerr << "Changing width will reset setting profile to '" << profile_name << "'\n";
-            }
-            width = atoi( *argv );
-            if ((width%32)!=0)
-            {
-                width = (width/32)*32;
-                std::cerr << "Width must be multiple of 32, rouding it down to '" << width << "'\n";
-            }
-            encoding_profile::profile_named( profile_name, width, height, custom_profile );
-        }
-        else if (!strcmp(*argv,"--height"))
-        {
-            argc--;
-            argv++;
-            if (profile_set)
-            {
-                std::cerr << "Changing height will reset setting profile to '" << profile_name << "'\n";
-            }
-            height = atoi( *argv );
-            encoding_profile::profile_named( profile_name, width, height, custom_profile );
-        }
-        else if (!strcmp(*argv,"--byterate"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_byterate( atoi( *argv ) );
-        }
-        else if (!strcmp(*argv,"--fps"))
-        {
-            argc--;
-            argv++;
-            fps = atof(*argv);
-        }
-        else if (!strcmp(*argv,"--fps-ratio"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_fps_ratio( atoi(*argv) );
-        }
-        else if (!strcmp(*argv,"--group"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_group( bool_from(*argv) );
-        }
-        else if (!strcmp(*argv,"--debug"))
-        {
-            argc--;
-            argv++;
-            sDebug = bool_from( *argv );
-        }
-        else if (!strcmp(*argv,"--from"))
-        {
-            argc--;
-            argv++;
-            from_index = seconds_from_string(*argv);
-        }
-        else if (!strcmp(*argv,"--to"))
-        {
-            argc--;
-            argv++;
-            to_index = atof(*argv);
-        }
-        else if (!strcmp(*argv,"--duration"))
-        {
-            argc--;
-            argv++;
-            duration = seconds_from_string(*argv);
-        }
-        else if (!strcmp(*argv,"--cover-from"))
-        {
-            argc--;
-            argv++;
-            cover_from = atoi(*argv);
-        }
-        else if (!strcmp(*argv,"--cover-to"))
-        {
-            argc--;
-            argv++;
-            cover_to = atoi(*argv);
-        }
-        else if (!strcmp(*argv,"--cover"))  //  #### KILL ME
-        {
-            argc--;
-            argv++;
-            cover_from = atoi(*argv);
-            cover_to = cover_from+23;
-        }
-        else if (!strcmp(*argv,"--poster"))
-        {
-            argc--;
-            argv++;
-            poster_ts = seconds_from_string(*argv);
-        }
-        else if (!strcmp(*argv,"--audio"))
-        {
-            argc--;
-            argv++;
-            audio_arg = *argv;
-        }
-        else if (!strcmp(*argv,"--flim"))
-        {
-            argc--;
-            argv++;
-            out_arg = *argv;
-        }
-        else if (!strcmp(*argv,"--out-pattern") || !strcmp(*argv,"--pgm-pattern") || !strcmp(*argv,"--pgm"))
-        {
-            argc--;
-            argv++;
-            pgm_pattern = *argv;
-        }
-        else if (!strcmp(*argv,"--diff-pattern"))
-        {
-            argc--;
-            argv++;
-            diff_pattern = *argv;
-        }
-        else if (!strcmp(*argv,"--change-pattern"))
-        {
-            argc--;
-            argv++;
-            change_pattern = *argv;
-        }
-        else if (!strcmp(*argv,"--target-pattern"))
-        {
-            argc--;
-            argv++;
-            target_pattern = *argv;
-        }
-        else if (!strcmp(*argv,"--comment"))
-        {
-            argc--;
-            argv++;
-            comment += "comment: ";
-            comment += *argv;
-            comment += "\n";
-        }
-        else if (!strcmp(*argv,"--watermark"))
-        {
-            argc--;
-            argv++;
-            if (!strcmp(*argv,"auto"))
-                auto_watermark = true;
-            else
-                watermark = *argv;
-        }
-        else if (!strcmp(*argv,"--filters"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_filters( *argv );
-        }
-        else if (!strcmp(*argv,"--bars"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_bars( bool_from(*argv) );
-        }
-        else if (!strcmp(*argv,"--codec"))
-        {
-            argc--;
-            argv++;
-            //  --codec z32 --codec line-copy:count=20
-            // codecs.push_back( flimcompressor::make_codec( "z32", 512, 342, "" ) );
-            // codecs.push_back( flimcompressor::make_codec( "lines", 512, 342, "" ) );
-            // codecs.push_back( flimcompressor::make_codec( "null", 512, 342, "" ) );
-            // codecs.push_back( flimcompressor::make_codec( "invert", 512, 342, "" ) );
-            codecs.push_back( flimcompressor::make_codec( *argv, width, height ) );
-        }
-        else if (!strcmp(*argv,"--dither"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_dither( *argv );
-        }
-        else if (!strcmp(*argv,"--error-stability"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_stability( atof( *argv ) );
-        }
-        else if (!strcmp(*argv,"--error-algorithm"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_error_algorithm( *argv );
-        }
-        else if (!strcmp(*argv,"--error-bleed"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_error_bleed( atof(*argv) );
-        }
-        else if (!strcmp(*argv,"--error-bidi"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_error_bidi( bool_from(*argv) );
-        }
-        else if (!strcmp(*argv,"--silent"))
-        {
-            argc--;
-            argv++;
-            custom_profile.set_silent( bool_from(*argv) );
-        }
-        else
-        {
-            std::cerr << "Unknown argument " << *argv << "\n";
-            return EXIT_FAILURE;
-        }
+        packz32opt_test();
+        test_seconds_from_string();
 
         argc--;
         argv++;
-    }
 
-    if (input_file=="")
-    {
-        usage( cmd_name );
-        exit( EXIT_FAILURE );
-    }
-
-    std::vector<subtitle> subs;
-
-    if (srt_file!="")
-    {
-        std::ifstream ifs;
-
-        ifs.open( srt_file, std::ifstream::in );
-
-        if (!ifs.good())
-        {
-            std::cerr << "ERROR : Cannot open subtitle file [" << srt_file << "]\n";
-            exit( EXIT_FAILURE );
-        }
-
-        subs = ::read_subtitles( ifs );
-
-        ifs.close();
-
-        subs = ::subtitles_extract( subs, from_index, duration );
-    }
-
-    //  If input-file is an url, use youtube-dl to retreive content
-    if (input_file.rfind( "https://", 0 )==0)
-    {
-        if (std::filesystem::exists(cache_file))
-        {
-            input_file = cache_file;
-            std::clog << "Using cached file: '" << cache_file << "'\n";
-        }
-        else
-        {
-            // https://www.dailymotion.com/video/x1au0r --dither ordered --filters g1.5q5c
-
-            char buffer[1024];
-            auto input_url = input_file;
-
-            sprintf( buffer, "yt-dlp '%s' -f mp4 --output '%s'", input_file.c_str(), cache_file.c_str() );
-            int res = system( buffer );
-            if (res!=0)
-            {
-                std::clog << "yt-dlp not installed or failing, falling back to youtube-dl (code " << res << ")\n";
-
-                sprintf( buffer, "youtube-dl '%s' -f mp4 --output '%s'", input_file.c_str(), cache_file.c_str() );
-                res = system( buffer );
-                if (res!=0)
-                {
-                    std::clog << "youtube-dl failed with error " << res << "\n";
-                    exit( EXIT_FAILURE );
-                }
+        while (argc) {
+            if (!strcmp(*argv, "--help")) {
+                usage(cmd_name);
+                ::exit(EXIT_SUCCESS);
             }
 
-                //  Switch input file
-            input_file = cache_file;
-            downloaded_file = true;
+            if (strncmp(*argv, "--", 2)) {
+                if (input_file != "") {
+                    std::cerr << "Input file specified twice: '" << input_file << "' and '" << *argv << "'\n";
+                    ::exit(EXIT_FAILURE);
+                }
+                input_file = *argv;
+            } else if (!strcmp(*argv, "--cache")) {
+                argc--;
+                argv++;
+                cache_file = *argv;
+                generated_cache = false;
+            } else if (!strcmp(*argv, "--mp4")) {
+                argc--;
+                argv++;
+                mp4_file = *argv;
+            } else if (!strcmp(*argv, "--srt")) {
+                argc--;
+                argv++;
+                srt_file = *argv;
+            } else if (!strcmp(*argv, "--gif")) {
+                argc--;
+                argv++;
+                gif_file = *argv;
+            } else if (!strcmp(*argv, "--profile")) {
+                argc--;
+                argv++;
+                profile_name = *argv;
+                if (profile_name == "xl") {
+                    width = (720 / 32) * 32;
+                    height = 364;
+                    std::cerr << "xl -- setting resolution to " << width << "x" << height << "\n";
+                }
+                if (profile_name == "portable") {
+                    width = (640 / 32) * 32;
+                    height = 400;
+                    std::cerr << "portable -- setting resolution to " << width << "x" << height << "\n";
+                }
+                if (!encoding_profile::profile_named(profile_name, width, height, custom_profile)) {
+                    std::cerr << "Cannot find encoding profile '" << *argv << "'\n";
+                    ::exit(EXIT_FAILURE);
+                }
+                profile_set = true;
+            } else if (!strcmp(*argv, "--width")) {
+                argc--;
+                argv++;
+                if (profile_set) {
+                    std::cerr << "Changing width will reset setting profile to '" << profile_name << "'\n";
+                }
+                width = atoi(*argv);
+                if ((width % 32) != 0) {
+                    width = (width / 32) * 32;
+                    std::cerr << "Width must be multiple of 32, rounding it down to '" << width << "'\n";
+                }
+                encoding_profile::profile_named(profile_name, width, height, custom_profile);
+            } else if (!strcmp(*argv, "--height")) {
+                argc--;
+                argv++;
+                if (profile_set) {
+                    std::cerr << "Changing height will reset setting profile to '" << profile_name << "'\n";
+                }
+                height = atoi(*argv);
+                encoding_profile::profile_named(profile_name, width, height, custom_profile);
+            } else if (!strcmp(*argv, "--byterate")) {
+                argc--;
+                argv++;
+                custom_profile.set_byterate(atoi(*argv));
+            } else if (!strcmp(*argv, "--fps")) {
+                argc--;
+                argv++;
+                fps = atof(*argv);
+            } else if (!strcmp(*argv, "--fps-ratio")) {
+                argc--;
+                argv++;
+                custom_profile.set_fps_ratio(atoi(*argv));
+            } else if (!strcmp(*argv, "--group")) {
+                argc--;
+                argv++;
+                custom_profile.set_group(bool_from(*argv));
+            } else if (!strcmp(*argv, "--debug")) {
+                argc--;
+                argv++;
+                sDebug = bool_from(*argv);
+            } else if (!strcmp(*argv, "--from")) {
+                argc--;
+                argv++;
+                from_index = seconds_from_string(*argv);
+            } else if (!strcmp(*argv, "--to")) {
+                argc--;
+                argv++;
+                to_index = atof(*argv);
+            } else if (!strcmp(*argv, "--duration")) {
+                argc--;
+                argv++;
+                duration = seconds_from_string(*argv);
+            } else if (!strcmp(*argv, "--cover-from")) {
+                argc--;
+                argv++;
+                cover_from = atoi(*argv);
+            } else if (!strcmp(*argv, "--cover-to")) {
+                argc--;
+                argv++;
+                cover_to = atoi(*argv);
+            } else if (!strcmp(*argv, "--cover")) {
+                argc--;
+                argv++;
+                cover_from = atoi(*argv);
+                cover_to = cover_from + 23;
+            } else if (!strcmp(*argv, "--poster")) {
+                argc--;
+                argv++;
+                poster_ts = seconds_from_string(*argv);
+            } else if (!strcmp(*argv, "--audio")) {
+                argc--;
+                argv++;
+                audio_arg = *argv;
+            } else if (!strcmp(*argv, "--flim")) {
+                argc--;
+                argv++;
+                out_arg = *argv;
+            } else if (!strcmp(*argv, "--out-pattern") || !strcmp(*argv, "--pgm-pattern") || !strcmp(*argv, "--pgm")) {
+                argc--;
+                argv++;
+                pgm_pattern = *argv;
+            } else if (!strcmp(*argv, "--diff-pattern")) {
+                argc--;
+                argv++;
+                diff_pattern = *argv;
+            } else if (!strcmp(*argv, "--change-pattern")) {
+                argc--;
+                argv++;
+                change_pattern = *argv;
+            } else if (!strcmp(*argv, "--target-pattern")) {
+                argc--;
+                argv++;
+                target_pattern = *argv;
+            } else if (!strcmp(*argv, "--comment")) {
+                argc--;
+                argv++;
+                comment += "comment: ";
+                comment += *argv;
+                comment += "\n";
+            } else if (!strcmp(*argv, "--watermark")) {
+                argc--;
+                argv++;
+                if (!strcmp(*argv, "auto"))
+                    auto_watermark = true;
+                else
+                    watermark = *argv;
+            } else if (!strcmp(*argv, "--filters")) {
+                argc--;
+                argv++;
+                custom_profile.set_filters(*argv);
+            } else if (!strcmp(*argv, "--bars")) {
+                argc--;
+                argv++;
+                custom_profile.set_bars(bool_from(*argv));
+            } else if (!strcmp(*argv, "--codec")) {
+                argc--;
+                argv++;
+                codecs.push_back(flimcompressor::make_codec(*argv, width, height));
+            } else if (!strcmp(*argv, "--dither")) {
+                argc--;
+                argv++;
+                custom_profile.set_dither(*argv);
+            } else if (!strcmp(*argv, "--error-stability")) {
+                argc--;
+                argv++;
+                custom_profile.set_stability(atof(*argv));
+            } else if (!strcmp(*argv, "--error-algorithm")) {
+                argc--;
+                argv++;
+                custom_profile.set_error_algorithm(*argv);
+            } else if (!strcmp(*argv, "--error-bleed")) {
+                argc--;
+                argv++;
+                custom_profile.set_error_bleed(atof(*argv));
+            } else if (!strcmp(*argv, "--error-bidi")) {
+                argc--;
+                argv++;
+                custom_profile.set_error_bidi(bool_from(*argv));
+            } else if (!strcmp(*argv, "--silent")) {
+                argc--;
+                argv++;
+                custom_profile.set_silent(bool_from(*argv));
+            } else {
+                std::cerr << "Unknown argument " << *argv << "\n";
+                return EXIT_FAILURE;
+            }
+
+            argc--;
+            argv++;
         }
-    }
 
-    if (poster_ts==-1)
-        poster_ts = duration/3;
+        if (input_file == "") {
+            usage(cmd_name);
+            exit(EXIT_FAILURE);
+        }
 
-    if (codecs.size()>1)
-    {
-        custom_profile.set_codecs( codecs );
-    }
+        std::vector<subtitle> subs;
 
-    if (auto_watermark)
-    {
-        if (watermark.size()>0)
-            watermark += " ";
-        watermark += custom_profile.description();
-    }
+        if (srt_file != "") {
+            std::ifstream ifs;
+            ifs.open(srt_file, std::ifstream::in);
 
-    std::clog << "Encoding arguments :\n" << custom_profile.description() << "\n";
+            if (!ifs.good()) {
+                std::cerr << "ERROR: Cannot open subtitle file [" << srt_file << "]\n";
+                exit(EXIT_FAILURE);
+            }
 
-    std::unique_ptr<input_reader> r;
-    if (ends_with( input_file, ".pgm" ))
-    {
-        std::clog << "Reading pgm from '" << input_file << "' pattern, at " << fps << " frames per second, using '" << audio_arg << "' audio file\n";
-        std::clog << "( use --fps and --audio to change fps and audio )\n";
-        r = std::make_unique<filesystem_reader>( input_file, fps, audio_arg, from_index, to_index );
-    }
-    else
-    {
-        r = make_ffmpeg_reader( input_file, from_index, duration );
-        fps = r->frame_rate();
-    }
+            subs = ::read_subtitles(ifs);
+            ifs.close();
+            subs = ::subtitles_extract(subs, from_index, duration);
+        }
 
-    std::vector<std::unique_ptr<output_writer>> w;
-    if (mp4_file!="")
-        w.push_back( make_ffmpeg_writer( mp4_file, custom_profile.width(), custom_profile.height() ) );
-    if (gif_file!="")
-        w.push_back( make_gif_writer( gif_file, custom_profile.width(), custom_profile.height() ) );
+        // If input-file is a URL, use yt-dlp to retrieve content
+        if (input_file.rfind("https://", 0) == 0) {
+            if (std::filesystem::exists(cache_file)) {
+                input_file = cache_file;
+                std::clog << "Using cached file: '" << cache_file << "'\n";
+            } else {
+                char buffer[1024];
+                auto input_url = input_file;
 
-    auto encoder = flimencoder{ custom_profile };
-    encoder.set_fps( fps );
-    encoder.set_comment( comment );
-    encoder.set_cover( cover_from, cover_to+1 );
-    encoder.set_watermark( watermark );
-    encoder.set_out_pattern( pgm_pattern );
-    encoder.set_diff_pattern( diff_pattern );
-    encoder.set_change_pattern( change_pattern );
-    encoder.set_target_pattern( target_pattern );
+                sprintf(buffer, "yt-dlp '%s' -f mp4 --output '%s'", input_file.c_str(), cache_file.c_str());
+                int res = system(buffer);
+                if (res != 0) {
+                    std::clog << "yt-dlp not installed or failing, falling back to youtube-dl (code " << res << ")\n";
+                    sprintf(buffer, "youtube-dl '%s' -f mp4 --output '%s'", input_file.c_str(), cache_file.c_str());
+                    res = system(buffer);
+                    if (res != 0) {
+                        std::clog << "youtube-dl failed with error " << res << "\n";
+                        exit(EXIT_FAILURE);
+                    }
+                }
 
-    encoder.set_poster_ts( poster_ts );
-    encoder.set_subtitles( subs );
+                // Switch input file
+                input_file = cache_file;
+                downloaded_file = true;
+            }
+        }
 
-    // encoder.set_input_single_random();
+        if (poster_ts == -1)
+            poster_ts = duration / 3;
 
-        encoder.make_flim( out_arg, r.get(), w );
+        if (codecs.size() > 1) {
+            custom_profile.set_codecs(codecs);
+        }
 
-        if (downloaded_file && generated_cache)
-        {
+        if (auto_watermark) {
+            if (watermark.size() > 0)
+                watermark += " ";
+            watermark += custom_profile.description();
+        }
+
+        std::clog << "Encoding arguments :\n" << custom_profile.description() << "\n";
+
+        std::unique_ptr<input_reader> r;
+        if (ends_with(input_file, ".pgm")) {
+            std::clog << "Reading pgm from '" << input_file << "' pattern, at " << fps << " frames per second, using '" << audio_arg << "' audio file\n";
+            std::clog << "( use --fps and --audio to change fps and audio )\n";
+            r = std::make_unique<filesystem_reader>(input_file, fps, audio_arg, from_index, to_index);
+        } else {
+            r = make_ffmpeg_reader(input_file, from_index, duration);
+            fps = r->frame_rate();
+        }
+
+        std::vector<std::unique_ptr<output_writer>> w;
+        if (mp4_file != "")
+            w.push_back(make_ffmpeg_writer(mp4_file, custom_profile.width(), custom_profile.height()));
+        if (gif_file != "")
+            w.push_back(make_gif_writer(gif_file, custom_profile.width(), custom_profile.height()));
+
+        auto encoder = flimencoder{ custom_profile };
+        encoder.set_fps(fps);
+        encoder.set_comment(comment);
+        encoder.set_cover(cover_from, cover_to + 1);
+        encoder.set_watermark(watermark);
+        encoder.set_out_pattern(pgm_pattern);
+        encoder.set_diff_pattern(diff_pattern);
+        encoder.set_change_pattern(change_pattern);
+        encoder.set_target_pattern(target_pattern);
+        encoder.set_poster_ts(poster_ts);
+        encoder.set_subtitles(subs);
+
+        encoder.make_flim(out_arg, r.get(), w);
+
+        if (downloaded_file && generated_cache) {
             std::clog << "Removing '" << cache_file << "'\n";
-            unlink( cache_file.c_str() );
+            unlink(cache_file.c_str());
         }
-    }
-    catch (const char *error)
-    {
-        std::cerr << "**** ERROR : [" << error << "]\n";
+    } catch (const char *error) {
+        std::cerr << "**** ERROR: [" << error << "]\n";
         return EXIT_FAILURE;
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -932,7 +932,7 @@ void error_diffusion( image &dest, const image &source, const image &previous, f
                 float e = error * t.amount;
                 size_t tx = x+t.dx*dir;
                 size_t ty = y+t.dy;
-                if (tx>=0 && tx<source.W() && ty>=0 && ty<source.H())
+                if (tx < source.W() && ty < source.H())
                     dest.at(tx,ty) = dest.at(tx,ty) + e;
             }
         }

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -43,16 +43,16 @@ public:
 
     const float &at( size_t x, size_t y ) const
     {
-        assert( x>=0 );
-        assert( y>=0 );
+        assert( x < W_ );
+        assert( y < H_ );
         assert( x<W_ );
         assert( y<H_ );
         return image_[x+y*W_];
     }
     float &at( size_t x, size_t y )
     {
-        assert( x>=0 );
-        assert( y>=0 );
+        assert( x < W_ );
+        assert( y < H_ );
         assert( x<W_ );
         assert( y<H_ );
         return image_[x+y*W_];

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1,6 +1,6 @@
 #include "reader.hpp"
 
-extern "C"{
+extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/samplefmt.h>
@@ -9,71 +9,69 @@ extern "C"{
 }
 
 #include <array>
+#include <iostream>
+#include <stdexcept>
+#include <cstring>
+#include <algorithm>
 
 extern bool sDebug;
 
-/// This stores a sound buffer and transform it into a suitable format for flims
 class sound_buffer
 {
     std::vector<float> data_;
-
-    size_t channel_count_ = 0;      //  # of channels
-    size_t sample_rate_ = 0;        //  # of samples per second
-
+    size_t channel_count_ = 0;
+    size_t sample_rate_ = 0;
     float min_sample_;
     float max_sample_;
 
 public:
-    sound_buffer( size_t channel_count, size_t sample_rate ) :
+    sound_buffer(size_t channel_count, size_t sample_rate) :
         channel_count_{channel_count},
-        sample_rate_ {sample_rate}
+        sample_rate_{sample_rate}
     {}
 
-    //  Append silence
-    void append_silence( float duration )
+    void append_silence(float duration)
     {
         size_t sample_count = sample_rate_ * duration;
-        for (size_t i=0;i!=sample_count;i++)
-        {
-            data_.push_back( 0 );
-        }
+        data_.insert(data_.end(), sample_count, 0.0f);
     }
 
-    //  Append sample_count samples over each of the channels
-    void append_samples( float **samples, size_t sample_count )
+    void append_samples(float **samples, size_t sample_count)
     {
-        for (size_t i=0;i!=sample_count;i++)
+        for (size_t i = 0; i < sample_count; i++)
         {
             float v = 0;
-            for (size_t j=0;j!=channel_count_;j++)
+            for (size_t j = 0; j < channel_count_; j++)
                 v += samples[j][i];
-
-            data_.push_back( v/channel_count_ );
+            data_.push_back(v / channel_count_);
         }
     }
 
     void process()
     {
-        min_sample_ = *std::min_element( std::begin(data_), std::end(data_) );
-        max_sample_ = *std::max_element( std::begin(data_), std::end(data_) );
+        if (data_.empty()) {
+            min_sample_ = max_sample_ = 0.0f;
+            return;
+        }
+        min_sample_ = *std::min_element(data_.begin(), data_.end());
+        max_sample_ = *std::max_element(data_.begin(), data_.end());
     }
 
-    //  Extract a 370 bytes frames (1/60th of a second)
-    std::unique_ptr<sound_frame_t> extract( size_t frame )
+    std::unique_ptr<sound_frame_t> extract(size_t frame)
     {
-        double t = frame / 60.0;        //  Time in seconds
+        double t = frame / 60.0;
         size_t start = t * sample_rate_;
 
-        if (start>=data_.size())
+        if (start >= data_.size())
             return nullptr;
 
         auto fr = std::make_unique<sound_frame_t>();
 
-        for (int i=0;i!=sound_frame_t::size;i++)
+        for (size_t i = 0; i < sound_frame_t::size; i++)
         {
-            size_t index = start+(i/370.0/60.0)*sample_rate_;
-            if (index<data_.size())
-                fr->at(i) = (data_[index]-min_sample_)/(max_sample_-min_sample_)*255;
+            size_t index = start + (i / 370.0 / 60.0) * sample_rate_;
+            if (index < data_.size())
+                fr->at(i) = (data_[index] - min_sample_) / (max_sample_ - min_sample_) * 255;
             else
                 fr->at(i) = 128;
         }
@@ -85,251 +83,171 @@ public:
 class ffmpeg_reader : public input_reader
 {
     AVFormatContext *format_context_ = nullptr;
-    AVCodec *video_decoder_;
-    AVCodec *audio_decoder_;
-    AVStream *video_stream_;
-    AVStream *audio_stream_;
-
-    AVCodecContext *video_codec_context_;
-    AVCodecContext *audio_codec_context_;
-
+    const AVCodec *video_decoder_ = nullptr;
+    const AVCodec *audio_decoder_ = nullptr;
+    AVStream *video_stream_ = nullptr;
+    AVStream *audio_stream_ = nullptr;
+    AVCodecContext *video_codec_context_ = nullptr;
+    AVCodecContext *audio_codec_context_ = nullptr;
     uint8_t *video_dst_data_[4] = {NULL};
     int video_dst_linesize_[4];
-
-    AVPacket pkt_;
-    AVFrame *frame_;
-
-    int ixv;    //  Video frame index
-    int ixa;    //  Audio frame index
-
+    AVPacket *pkt_ = nullptr;
+    AVFrame *frame_ = nullptr;
+    int ixv = -1;
+    int ixa = -1;
     size_t video_frame_count = 0;
-
-    std::unique_ptr<image> video_image_;        //  Size of the video input
-    std::unique_ptr<image> default_image_;      //  Size of our output
-
+    std::unique_ptr<image> video_image_;
+    std::unique_ptr<image> default_image_;
     std::vector<image> images_;
-
     std::unique_ptr<sound_buffer> sound_;
-
     int image_ix = -1;
     int sound_ix = -1;
-
     double first_frame_second_;
     size_t frame_to_extract_;
+    bool found_sound_ = false;
 
-    bool found_sound_ = false;                   //  To track if sounds starts with an offset
-
-    int decode_packet(int *got_frame, AVPacket &pkt)
+    int decode_packet(int *got_frame, AVPacket *pkt)
     {
         int ret = 0;
-        int decoded = pkt.size;
         *got_frame = 0;
 
-        if (pkt.stream_index == ixv)
+        if (pkt->stream_index == ixv)
         {
-            /* decode video frame */
-            ret = avcodec_decode_video2( video_codec_context_, frame_, got_frame, &pkt );
+            ret = avcodec_send_packet(video_codec_context_, pkt);
             if (ret < 0) {
-                // fprintf(stderr, "Error decoding video frame (%s)\n", av_err2str(ret));
-                throw "VIDEO FRAME DECODING ERROR";
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                std::cerr << "Error sending video packet for decoding: " << errbuf << std::endl;
+                return ret;
             }
-#define noVERBOSE
 
-#ifdef VERBOSE
-    std::clog << "*" << std::flush;
-#endif
-
-            if (*got_frame)
+            while (ret >= 0)
             {
-                // if (frame->width != width || frame->height != height ||
-                //     frame->format != pix_fmt)
-                //         throw "VIDEO FRAME DEFINITION CHANGED";     //  We could handle that by changing the image
-                /* copy decoded frame to destination buffer:
-                * this is required since rawvideo expects non aligned data */
-#ifdef VERBOSE
-    std::clog << "VIDEO FRAME TS = " << frame_->pts*av_q2d(video_stream_->time_base) << "\n";
-#endif
-
-                if (frame_->pts*av_q2d(video_stream_->time_base)>=first_frame_second_ && images_.size()<=video_frame_count)
+                ret = avcodec_receive_frame(video_codec_context_, frame_);
+                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
                 {
-#ifdef VERBOSE
-                    printf("video_frame%s n:%d coded_n:%d presentation_ts:%ld / %f\n",
-                        cached ? "(cached)" : "",
-                        video_frame_count, frame_->coded_picture_number, frame_->pts, frame_->pts*av_q2d(video_stream_->time_base) );
-#endif
+                    break;
+                }
+                else if (ret < 0)
+                {
+                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                    std::cerr << "Error receiving decoded video frame: " << errbuf << std::endl;
+                    return ret;
+                }
+
+                *got_frame = 1;
+
+                double frame_pts = frame_->pts * av_q2d(video_stream_->time_base);
+                if (frame_pts >= first_frame_second_ && images_.size() < frame_to_extract_)
+                {
                     video_frame_count++;
-                    std::clog << "Read " << video_frame_count << " frames\r" << std::flush;
+                    std::clog << "Read " << video_frame_count << " frames, PTS: " << frame_pts << "\r" << std::flush;
 
                     av_image_copy(
                         video_dst_data_, video_dst_linesize_,
-                                (const uint8_t **)(frame_->data), frame_->linesize,
-                                video_codec_context_->pix_fmt, video_codec_context_->width, video_codec_context_->height );
+                        (const uint8_t **)(frame_->data), frame_->linesize,
+                        video_codec_context_->pix_fmt, video_codec_context_->width, video_codec_context_->height);
+                    
+                    video_image_->set_luma(video_dst_data_[0]);
+                    images_.push_back(*default_image_);
+                    copy(images_.back(), *video_image_);
 
-                    // copy into image
-                    video_image_->set_luma( video_dst_data_[0] );
-
-                    images_.push_back( *default_image_ );
-                    copy( images_.back(), *video_image_ );
-
-                    // write_image( "/tmp/dump.pgm", *video_image_ );
+                    if (sDebug)
+                        std::clog << "Copied frame " << video_frame_count << " to images_\n";
                 }
-#ifdef VERBOSE
-                else
-                    std::clog << "." << std::flush;  //  We are skipping frames
-#endif
 
-                // images_[video_frame_count].set_luma( video_dst_data_[0] );
+                av_frame_unref(frame_);
             }
         }
-        else if (pkt.stream_index == ixa)
+        else if (pkt->stream_index == ixa)
         {
-#if 0
-std::clog << "avcodec_receive_frame => ";
-        ret = avcodec_receive_frame(audio_codec_context_,frame_);
-std::clog << ret << "\n";
-        if (ret == 0)
-            *got_frame = true;
-        if (ret == AVERROR(EAGAIN))
-            return 0;
-        if (ret == 0)
-        {
-            std::clog << "avcodec_send_packet => ";
-            ret = avcodec_send_packet(audio_codec_context_, &pkt);
-            std::clog << ret << "\n";
-        }
-        if (ret == AVERROR(EAGAIN))
-            return 0;
-#else
-            ret = avcodec_decode_audio4(audio_codec_context_, frame_, got_frame, &pkt);
-            if (ret < 0)
-            {
-//                auto s = av_err2str(ret);
-                throw "AUDIO FRAME DECODING ERROR";
+            ret = avcodec_send_packet(audio_codec_context_, pkt);
+            if (ret < 0) {
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                std::cerr << "Error sending audio packet for decoding: " << errbuf << std::endl;
+                return ret;
             }
-#endif
-          /* Some audio decoders decode only part of the packet, and have to be
-           * called again with the remainder of the packet data.
-           * Sample: fate-suite/lossless-audio/luckynight-partial.shn
-           * Also, some decoders might over-read the packet. */
-          decoded = FFMIN(ret, pkt.size);
-  
 
-//  static int audio_frame_count = 0; 
-
-          if (*got_frame)
-          {
-#ifdef VERBOSE
-            std::clog << "AUDIO: " << frame_->pts*av_q2d(audio_stream_->time_base) << " sample count " << frame_->nb_samples << "\n";
-#endif
-            if (frame_->pts*av_q2d(audio_stream_->time_base)>=first_frame_second_)
+            while (ret >= 0)
             {
-#ifdef VERBOSE
-            std::clog << "USING AUDIO FRAME\n";
-#endif
-
-            if (!found_sound_)
-            {
-                found_sound_ = true;
-                auto skip = frame_->pts*av_q2d(audio_stream_->time_base)-first_frame_second_;
-                if (skip>0)
+                ret = avcodec_receive_frame(audio_codec_context_, frame_);
+                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
                 {
-                    std::clog << "Inserting " << skip << " seconds of silence\n";
-                    sound_->append_silence( skip );
+                    break;
                 }
+                else if (ret < 0)
+                {
+                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                    std::cerr << "Error receiving decoded audio frame: " << errbuf << std::endl;
+                    return ret;
+                }
+
+                *got_frame = 1;
+
+                double frame_pts = frame_->pts * av_q2d(audio_stream_->time_base);
+                if (frame_pts >= first_frame_second_)
+                {
+                    if (!found_sound_)
+                    {
+                        found_sound_ = true;
+                        auto skip = frame_pts - first_frame_second_;
+                        if (skip > 0)
+                        {
+                            std::clog << "Inserting " << skip << " seconds of silence\n";
+                            sound_->append_silence(skip);
+                        }
+                    }
+                    sound_->append_samples((float **)frame_->extended_data, frame_->nb_samples);
+                }
+
+                av_frame_unref(frame_);
             }
-
-            //   size_t unpadded_linesize = frame_->nb_samples * av_get_bytes_per_sample((AVSampleFormat)frame_->format);
-            //   printf("audio_frame%s n:%d nb_samples:%d pts:%s\n",
-            //          cached ? "(cached)" : "",
-            //          audio_frame_count++, frame_->nb_samples,
-            //          av_ts2timestr(frame_->pts, &audio_codec_context_->time_base));
-  
-              /* Write the raw audio data samples of the first plane. This works
-               * fine for packed formats (e.g. AV_SAMPLE_FMT_S16). However,
-               * most audio decoders output planar audio, which uses a separate
-               * plane of audio samples for each channel (e.g. AV_SAMPLE_FMT_S16P).
-               * In other words, this code will write only the first audio channel
-               * in these cases.
-               * You should use libswresample or libavfilter to convert the frame
-               * to packed data. */
-            //   fwrite(frame->extended_data[0], 1, unpadded_linesize, audio_dst_file);
-
-// std::clog << frame_->nb_samples << " (" << unpadded_linesize << " bytes) :";
-
-// for (int i=0;i!=frame_->nb_samples;i++)
-// {
-//     float v = 0;
-//     for (int j=0;j!=audio_codec_context_->channels;j++)
-//         v += ((float *)frame_->extended_data[j])[i];
-
-//     std::clog << v/audio_codec_context_->channels << " ";
-// }
-// std::clog << "\n";
-
-            sound_->append_samples( (float **)frame_->extended_data, frame_->nb_samples );
-          }
-        //   else
-        //     std::clog << "." << std::flush;
-          }
         }
 
-        extern bool sDebug;
-        if (sDebug)
-            std::clog << "decode_packet returing " << decoded << "\n";
-
-        return decoded;
+        return 0;
     }
 
 public:
     ffmpeg_reader() {}
 
-    ffmpeg_reader( const std::string &movie_path, double from, double duration )
+    ffmpeg_reader(const std::string &movie_path, double from, double duration)
     {
+        av_log_set_level(AV_LOG_WARNING);
 
-        av_log_set_level( AV_LOG_WARNING );
+        int ret = avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL);
+        if (ret != 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("Cannot open input file: ") + errbuf);
+        }
 
-        //open video file
-        if (avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL) != 0)
-            throw "Cannot open input file";
-
-        //get stream info
-        if (avformat_find_stream_info(format_context_, NULL) < 0)
-            throw "Cannot find stream information";
-
-        // dump the whole thing like ffprobe does
-        //av_dump_format(pFormatCtx, 0, argv[1], 0);
+        ret = avformat_find_stream_info(format_context_, NULL);
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("Cannot find stream information: ") + errbuf);
+        }
 
         if (sDebug)
             std::clog << "Searching for audio and video in " << format_context_->nb_streams << " streams\n";
 
-        ixv = av_find_best_stream( format_context_,
-                        AVMEDIA_TYPE_VIDEO,
-                        -1,
-                        -1,
-                        &video_decoder_,
-                        0 );
-        ixa = av_find_best_stream( format_context_,
-                        AVMEDIA_TYPE_AUDIO,
-                        -1,
-                        -1,
-                        &audio_decoder_,
-                        0 );
+        ixv = av_find_best_stream(format_context_, AVMEDIA_TYPE_VIDEO, -1, -1, &video_decoder_, 0);
+        ixa = av_find_best_stream(format_context_, AVMEDIA_TYPE_AUDIO, -1, -1, &audio_decoder_, 0);
 
-        if (ixv==AVERROR_STREAM_NOT_FOUND)
-        {
-            throw "NO VIDEO IN FILE\n";
+        if (ixv == AVERROR_STREAM_NOT_FOUND) {
+            throw std::runtime_error("NO VIDEO IN FILE");
         }
-        if (ixv==AVERROR_DECODER_NOT_FOUND)
-        {
-            throw "NO SUITABLE VIDEO DECODER AVAILABLE\n";
+        if (ixv == AVERROR_DECODER_NOT_FOUND) {
+            throw std::runtime_error("NO SUITABLE VIDEO DECODER AVAILABLE");
         }
-        if (ixa==AVERROR_STREAM_NOT_FOUND)
-        {
+        if (ixa == AVERROR_STREAM_NOT_FOUND) {
             std::cerr << "NO SOUND -- INSERTING SILENCE";
         }
-        if (ixa==AVERROR_DECODER_NOT_FOUND)
-        {
-            throw "NO SUITABLE AUDIO DECODER AVAILABLE\n";
+        if (ixa == AVERROR_DECODER_NOT_FOUND) {
+            throw std::runtime_error("NO SUITABLE AUDIO DECODER AVAILABLE");
         }
 
         if (sDebug)
@@ -338,182 +256,189 @@ public:
             std::clog << "Audio stream index :" << ixa << "\n";
         }
 
-        double seek_to = std::max(from-10.0,0.0);    //  We seek to 10 seconds earlier, if we can
-        if (avformat_seek_file( format_context_, -1, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, AVSEEK_FLAG_ANY )<0)
-            throw "CANNOT SEEK IN FILE\n";
-        // if (avformat_seek_file( format_context_, ixv, 0, 0, 0, AVSEEK_FLAG_FRAME )<0)
-        //     throw "CANNOT SEEK IN FILE\n";
+        double seek_to = std::max(from - 10.0, 0.0);
+        ret = avformat_seek_file(format_context_, -1, seek_to * AV_TIME_BASE, seek_to * AV_TIME_BASE, seek_to * AV_TIME_BASE, AVSEEK_FLAG_ANY);
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("CANNOT SEEK IN FILE: ") + errbuf);
+        }
 
         video_stream_ = format_context_->streams[ixv];
-        audio_stream_ = ixa!=AVERROR_STREAM_NOT_FOUND?format_context_->streams[ixa]:nullptr;
-
-        // get the frame rate of each stream
+        audio_stream_ = ixa != AVERROR_STREAM_NOT_FOUND ? format_context_->streams[ixa] : nullptr;
 
         if (sDebug)
         {
-            std::clog   << "Video : "
-                        << " " << video_stream_->codecpar->width << "x" << video_stream_->codecpar->height
-                        << "@" << av_q2d( video_stream_->r_frame_rate )
-                        << " fps" 
-                        << " timebase:" 
-                        << av_q2d(video_stream_->time_base)
-                        << "\n";
-            std::clog   << "Audio : "
-                        << " " << audio_stream_->codecpar->sample_rate
-                        << "Hz \n";
+            std::clog << "Video : "
+                      << " " << video_stream_->codecpar->width << "x" << video_stream_->codecpar->height
+                      << "@" << av_q2d(video_stream_->r_frame_rate)
+                      << " fps"
+                      << " timebase:"
+                      << av_q2d(video_stream_->time_base)
+                      << "\n";
+            if (audio_stream_)
+            {
+                std::clog << "Audio : "
+                          << " " << audio_stream_->codecpar->sample_rate
+                          << "Hz \n";
+            }
         }
 
         first_frame_second_ = from;
-        frame_to_extract_ = duration*av_q2d( video_stream_->r_frame_rate );
+        frame_to_extract_ = duration * av_q2d(video_stream_->r_frame_rate);
 
-//      non needed, the decoder was found by av_find_best_stream
-//        dec = avcodec_find_decoder( video_stream_->codecpar->codec_id );
-
-            //  allocate the context
-        video_codec_context_ = avcodec_alloc_context3( video_decoder_ );
+        video_codec_context_ = avcodec_alloc_context3(video_decoder_);
         if (!video_codec_context_)
-            throw "CANNOT ALLOCATE VIDEO CODEC CONTEXT\n";
+            throw std::runtime_error("CANNOT ALLOCATE VIDEO CODEC CONTEXT");
 
-            //  copy the parameters
-        if (avcodec_parameters_to_context( video_codec_context_, video_stream_->codecpar ) < 0)
-            throw "FAILED TO COPY VIDEO CODEC PARAMETERS\n";
+        ret = avcodec_parameters_to_context(video_codec_context_, video_stream_->codecpar);
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("FAILED TO COPY VIDEO CODEC PARAMETERS: ") + errbuf);
+        }
 
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
+        if (ixa != AVERROR_STREAM_NOT_FOUND)
         {
-            audio_codec_context_ = avcodec_alloc_context3( audio_decoder_ );
-            // audio_codec_context_ = format_context_->streams[ixa]->codec;
+            audio_codec_context_ = avcodec_alloc_context3(audio_decoder_);
             if (!audio_codec_context_)
-                throw "CANNOT ALLOCATE AUDIO CODEC CONTEXT\n";
+                throw std::runtime_error("CANNOT ALLOCATE AUDIO CODEC CONTEXT");
 
-            if (avcodec_parameters_to_context( audio_codec_context_, audio_stream_->codecpar ) < 0)
-                throw "FAILED TO COPY AUDIO CODEC PARAMETERS\n";
+            ret = avcodec_parameters_to_context(audio_codec_context_, audio_stream_->codecpar);
+            if (ret < 0) {
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                throw std::runtime_error(std::string("FAILED TO COPY AUDIO CODEC PARAMETERS: ") + errbuf);
+            }
         }
 
         AVDictionary *opts = NULL;
+        av_dict_set(&opts, "refcounted_frames", "0", 0);
 
-        av_dict_set(&opts, "refcounted_frames", "0", 0);    //  Do not refcount
+        ret = avcodec_open2(video_codec_context_, video_decoder_, &opts);
+        if (ret < 0) {
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("CANNOT OPEN VIDEO CODEC: ") + errbuf);
+        }
 
-        if (avcodec_open2( video_codec_context_, video_decoder_, &opts ) < 0)
-            throw "CANNOT OPEN VIDEO CODEC\n";
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
+        if (ixa != AVERROR_STREAM_NOT_FOUND)
         {
-            if (avcodec_open2( audio_codec_context_, audio_decoder_, nullptr ) < 0)
-                throw "CANNOT OPEN AUDIO CODEC\n";
+            ret = avcodec_open2(audio_codec_context_, audio_decoder_, nullptr);
+            if (ret < 0) {
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                throw std::runtime_error(std::string("CANNOT OPEN AUDIO CODEC: ") + errbuf);
+            }
+
             if (sDebug)
-                std::clog << "AUDIO CODEC: " << avcodec_get_name( audio_codec_context_->codec_id ) << "\n";
+                std::clog << "AUDIO CODEC: " << avcodec_get_name(audio_codec_context_->codec_id) << "\n";
 
             AVSampleFormat sfmt = audio_codec_context_->sample_fmt;
-            int n_channels = audio_codec_context_->channels;
+            int n_channels = audio_codec_context_->ch_layout.nb_channels;
 
-                if (sDebug)
-                {
-                    std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
-                    std::clog << "# CHANNELS   :" << n_channels << "\n";
-                    std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt)?"YES":"NO") << "\n";
-                }
+            if (sDebug)
+            {
+                std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
+                std::clog << "# CHANNELS   :" << n_channels << "\n";
+                std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt) ? "YES" : "NO") << "\n";
+            }
 
             if (av_sample_fmt_is_planar(sfmt))
             {
-            //          const char *packed = av_get_sample_fmt_name(sfmt);
-            //          printf("Warning: the sample format the decoder produced is planar "
-            //                 "(%s). This example will output the first channel only.\n",
-            //                 packed ? packed : "?");
-                    sfmt = av_get_packed_sample_fmt(sfmt);
+                sfmt = av_get_packed_sample_fmt(sfmt);
 
                 if (sDebug)
                 {
-                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
+                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
                     std::clog << "SAMPLE RATE  :" << audio_codec_context_->sample_rate << "\n";
                 }
-            //          n_channels = 1;
             }
-            sound_ = std::make_unique<sound_buffer>( n_channels, audio_codec_context_->sample_rate );
-
+            sound_ = std::make_unique<sound_buffer>(n_channels, audio_codec_context_->sample_rate);
         }
         else
             sound_ = nullptr;
 
-
         if (sDebug)
             std::clog << "VIDEO CODEC OPENED WITH PIXEL FORMAT " << av_get_pix_fmt_name(video_codec_context_->pix_fmt) << "\n";
 
-        if (video_codec_context_->pix_fmt!=AV_PIX_FMT_YUV420P)
-            throw "WAS EXPECTING A YUV240P PIXEL FORMAT";
+        if (video_codec_context_->pix_fmt != AV_PIX_FMT_YUV420P)
+            throw std::runtime_error("WAS EXPECTING A YUV420P PIXEL FORMAT");
 
-        auto bufsize = av_image_alloc(
+        int bufsize = av_image_alloc(
             video_dst_data_,
             video_dst_linesize_,
             video_codec_context_->width,
             video_codec_context_->height,
             video_codec_context_->pix_fmt,
-            1 );
+            1);
 
-        if (bufsize<0)
-            throw "CANNOT ALLOCATE IMAGE\n";
-
-        video_image_ = std::make_unique<image>( video_codec_context_->width, video_codec_context_->height );
-
-        double aspect = video_codec_context_->width/(double)video_codec_context_->height;
-        if (aspect>512/342.0)
+        if (bufsize < 0)
         {
-            default_image_ = std::make_unique<image>( 342*aspect, 342 );
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(bufsize, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            throw std::runtime_error(std::string("CANNOT ALLOCATE IMAGE: ") + errbuf);
+        }
+
+        video_image_ = std::make_unique<image>(video_codec_context_->width, video_codec_context_->height);
+
+        double aspect = video_codec_context_->width / (double)video_codec_context_->height;
+        if (aspect > 512 / 342.0)
+        {
+            default_image_ = std::make_unique<image>(342 * aspect, 342);
         }
         else
         {
-            default_image_ = std::make_unique<image>( 512, 512/aspect );
+            default_image_ = std::make_unique<image>(512, 512 / aspect);
         }
 
         if (sDebug)
         {
             std::clog << "Image structure:\n";
             std::clog << video_dst_linesize_[0] << " " << video_dst_linesize_[1] << " " << video_dst_linesize_[2] << " " << video_dst_linesize_[3] << "\n";
-            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + video_dst_linesize_[2] + video_dst_linesize_[3])*video_codec_context_->height << "\n";
+            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + video_dst_linesize_[2] + video_dst_linesize_[3]) * video_codec_context_->height << "\n";
             std::clog << bufsize << "\n";
         }
 
-        // std::clog << video_dst_data_[1]-video_dst_data_[0] << " " << video_dst_data_[2]-video_dst_data_[1] << " " << video_dst_data_[3]-video_dst_data_[2] << "\n";
-
         frame_ = av_frame_alloc();
+        if (!frame_)
+            throw std::runtime_error("Could not allocate frame");
 
-            //  Ready to read images
-        av_init_packet(&pkt_);
-        pkt_.data = NULL;
-        pkt_.size = 0;
+        pkt_ = av_packet_alloc();
+        if (!pkt_)
+            throw std::runtime_error("Could not allocate packet");
 
         int got_frame = 0;
 
-        while (av_read_frame(format_context_, &pkt_) >= 0)
+        while (av_read_frame(format_context_, pkt_) >= 0)
         {
-            do {
-                auto ret = decode_packet( &got_frame, pkt_ );
-                if (images_.size()==frame_to_extract_)
+            do
+            {
+                auto ret = decode_packet(&got_frame, pkt_);
+                if (images_.size() >= frame_to_extract_)
                     goto end;
                 if (ret < 0)
                     break;
-                pkt_.data += ret;
-                pkt_.size -= ret;
-            } while (pkt_.size > 0);
-        }
-        /* flush cached frames */
-        if (images_.size()!=frame_to_extract_)
-        {
-            pkt_.data = NULL;
-            pkt_.size = 0;
-            do {
-                decode_packet(&got_frame, pkt_);
-            } while (got_frame);
+            } while (pkt_->size > 0);
+            av_packet_unref(pkt_);
         }
 
-end:
+        // Flush the decoders
+        pkt_->data = NULL;
+        pkt_->size = 0;
+        do {
+            decode_packet(&got_frame, pkt_);
+        } while (got_frame);
 
+    end:
         std::clog << "\n";
 
         image_ix = 0;
 
         if (sDebug)
-            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of " << images_.size()/av_q2d( video_stream_->r_frame_rate ) << " seconds \n";
+            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of " << images_.size() / av_q2d(video_stream_->r_frame_rate) << " seconds \n";
 
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
+        if (ixa != AVERROR_STREAM_NOT_FOUND && sound_)
         {
             sound_->process();
             sound_ix = 0;
@@ -525,47 +450,60 @@ end:
 
     ~ffmpeg_reader()
     {
-        avformat_close_input( &format_context_);
+        avformat_close_input(&format_context_);
         if (sDebug)
             std::clog << "Closed media file\n";
+        if (video_codec_context_)
+            avcodec_free_context(&video_codec_context_);
+        if (audio_codec_context_)
+            avcodec_free_context(&audio_codec_context_);
+        if (frame_)
+            av_frame_free(&frame_);
+        if (pkt_)
+            av_packet_free(&pkt_);
+        if (video_dst_data_[0])
+            av_freep(&video_dst_data_[0]);
     }
 
-    virtual double frame_rate()
+    virtual double frame_rate() override
     {
-        return av_q2d( video_stream_->r_frame_rate );
+        return av_q2d(video_stream_->r_frame_rate);
     }
 
-    virtual std::unique_ptr<image> next()
+    virtual std::unique_ptr<image> next() override
     {
-        if (image_ix==-1)
+        if (sDebug) std::clog << "next() called, image_ix: " << image_ix << ", images_.size(): " << images_.size() << std::endl;
+        
+        if (image_ix == -1 || image_ix >= (int)images_.size())
+        {
+            if (sDebug) std::clog << "next() returning nullptr" << std::endl;
             return nullptr;
-        if (image_ix==(int)images_.size())
-            return nullptr;
-        auto res = std::make_unique<image>( images_[image_ix] );
+        }
+        auto res = std::make_unique<image>(images_[image_ix]);
         image_ix++;
+        if (sDebug) std::clog << "next() returning image, new image_ix: " << image_ix << std::endl;
         return res;
     }
 
-    virtual std::unique_ptr<sound_frame_t> next_sound()
+    virtual std::unique_ptr<sound_frame_t> next_sound() override
     {
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
+        if (ixa != AVERROR_STREAM_NOT_FOUND && sound_)
         {
-            auto s = std::make_unique<sound_frame_t>();
-            return sound_->extract( sound_ix++ );
+            return sound_->extract(sound_ix++);
         }
         return nullptr;
     }
 };
 
-std::unique_ptr<input_reader> make_ffmpeg_reader( const std::string &movie_path, double from, double to )
+std::unique_ptr<input_reader> make_ffmpeg_reader(const std::string &movie_path, double from, double to)
 {
     try
     {
-        return std::make_unique<ffmpeg_reader>( movie_path, from, to );
+        return std::make_unique<ffmpeg_reader>(movie_path, from, to - from);
     }
-    catch (const char *e)
+    catch (const std::exception& e)
     {
-        std::clog << "**** ERROR : " << e << "\n";
+        std::cerr << "**** ERROR: " << e.what() << std::endl;
         return nullptr;
     }
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -9,69 +9,71 @@ extern "C" {
 }
 
 #include <array>
-#include <iostream>
-#include <stdexcept>
-#include <cstring>
-#include <algorithm>
 
 extern bool sDebug;
 
+/// This stores a sound buffer and transform it into a suitable format for flims
 class sound_buffer
 {
     std::vector<float> data_;
-    size_t channel_count_ = 0;
-    size_t sample_rate_ = 0;
+
+    size_t channel_count_ = 0;      //  # of channels
+    size_t sample_rate_ = 0;        //  # of samples per second
+
     float min_sample_;
     float max_sample_;
 
 public:
-    sound_buffer(size_t channel_count, size_t sample_rate) :
+    sound_buffer( size_t channel_count, size_t sample_rate ) :
         channel_count_{channel_count},
-        sample_rate_{sample_rate}
+        sample_rate_ {sample_rate}
     {}
 
-    void append_silence(float duration)
+    //  Append silence
+    void append_silence( float duration )
     {
         size_t sample_count = sample_rate_ * duration;
-        data_.insert(data_.end(), sample_count, 0.0f);
+        for (size_t i=0;i!=sample_count;i++)
+        {
+            data_.push_back( 0 );
+        }
     }
 
-    void append_samples(float **samples, size_t sample_count)
+    //  Append sample_count samples over each of the channels
+    void append_samples( float **samples, size_t sample_count )
     {
-        for (size_t i = 0; i < sample_count; i++)
+        for (size_t i=0;i!=sample_count;i++)
         {
             float v = 0;
-            for (size_t j = 0; j < channel_count_; j++)
+            for (size_t j=0;j!=channel_count_;j++)
                 v += samples[j][i];
-            data_.push_back(v / channel_count_);
+
+            data_.push_back( v/channel_count_ );
         }
     }
 
     void process()
     {
-        if (data_.empty()) {
-            min_sample_ = max_sample_ = 0.0f;
-            return;
-        }
-        min_sample_ = *std::min_element(data_.begin(), data_.end());
-        max_sample_ = *std::max_element(data_.begin(), data_.end());
+        min_sample_ = *std::min_element( std::begin(data_), std::end(data_) );
+        max_sample_ = *std::max_element( std::begin(data_), std::end(data_) );
     }
 
-    std::unique_ptr<sound_frame_t> extract(size_t frame)
+    //  Extract a 370 bytes frames (1/60th of a second)
+    std::unique_ptr<sound_frame_t> extract( size_t frame )
     {
-        double t = frame / 60.0;
+        double t = frame / 60.0;        //  Time in seconds
         size_t start = t * sample_rate_;
 
-        if (start >= data_.size())
+        if (start>=data_.size())
             return nullptr;
 
         auto fr = std::make_unique<sound_frame_t>();
 
-        for (size_t i = 0; i < sound_frame_t::size; i++)
+        for (int i=0;i!=sound_frame_t::size;i++)
         {
-            size_t index = start + (i / 370.0 / 60.0) * sample_rate_;
-            if (index < data_.size())
-                fr->at(i) = (data_[index] - min_sample_) / (max_sample_ - min_sample_) * 255;
+            size_t index = start+(i/370.0/60.0)*sample_rate_;
+            if (index<data_.size())
+                fr->at(i) = (data_[index]-min_sample_)/(max_sample_-min_sample_)*255;
             else
                 fr->at(i) = 128;
         }
@@ -83,171 +85,189 @@ public:
 class ffmpeg_reader : public input_reader
 {
     AVFormatContext *format_context_ = nullptr;
-    const AVCodec *video_decoder_ = nullptr;
-    const AVCodec *audio_decoder_ = nullptr;
-    AVStream *video_stream_ = nullptr;
-    AVStream *audio_stream_ = nullptr;
-    AVCodecContext *video_codec_context_ = nullptr;
-    AVCodecContext *audio_codec_context_ = nullptr;
+    const AVCodec *video_decoder_;
+    const AVCodec *audio_decoder_;
+    AVStream *video_stream_;
+    AVStream *audio_stream_;
+
+    AVCodecContext *video_codec_context_;
+    AVCodecContext *audio_codec_context_;
+
     uint8_t *video_dst_data_[4] = {NULL};
     int video_dst_linesize_[4];
-    AVPacket *pkt_ = nullptr;
-    AVFrame *frame_ = nullptr;
-    int ixv = -1;
-    int ixa = -1;
+
+    AVPacket *pkt_;
+    AVFrame *frame_;
+
+    int ixv;    //  Video frame index
+    int ixa;    //  Audio frame index
+
     size_t video_frame_count = 0;
-    std::unique_ptr<image> video_image_;
-    std::unique_ptr<image> default_image_;
+
+    std::unique_ptr<image> video_image_;        //  Size of the video input
+    std::unique_ptr<image> default_image_;      //  Size of our output
+
     std::vector<image> images_;
+
     std::unique_ptr<sound_buffer> sound_;
+
     int image_ix = -1;
     int sound_ix = -1;
+
     double first_frame_second_;
     size_t frame_to_extract_;
-    bool found_sound_ = false;
+
+    bool found_sound_ = false;                   //  To track if sounds starts with an offset
 
     int decode_packet(int *got_frame, AVPacket *pkt)
     {
         int ret = 0;
+        int decoded = pkt->size;
         *got_frame = 0;
 
         if (pkt->stream_index == ixv)
         {
+            /* decode video frame */
             ret = avcodec_send_packet(video_codec_context_, pkt);
             if (ret < 0) {
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                std::cerr << "Error sending video packet for decoding: " << errbuf << std::endl;
-                return ret;
+                throw "Error sending video packet for decoding";
             }
 
-            while (ret >= 0)
-            {
+            while (ret >= 0) {
                 ret = avcodec_receive_frame(video_codec_context_, frame_);
-                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
-                {
+                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
                     break;
-                }
-                else if (ret < 0)
-                {
-                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                    std::cerr << "Error receiving decoded video frame: " << errbuf << std::endl;
-                    return ret;
+                } else if (ret < 0) {
+                    throw "Error during video decoding";
                 }
 
                 *got_frame = 1;
 
-                double frame_pts = frame_->pts * av_q2d(video_stream_->time_base);
-                if (frame_pts >= first_frame_second_ && images_.size() < frame_to_extract_)
+#ifdef VERBOSE
+                std::clog << "VIDEO FRAME TS = " << frame_->pts*av_q2d(video_stream_->time_base) << "\n";
+#endif
+
+                if (frame_->pts*av_q2d(video_stream_->time_base)>=first_frame_second_ && images_.size()<=video_frame_count)
                 {
+#ifdef VERBOSE
+                    printf("video_frame%s n:%d coded_n:%d presentation_ts:%ld / %f\n",
+                        cached ? "(cached)" : "",
+                        video_frame_count, frame_->coded_picture_number, frame_->pts, frame_->pts*av_q2d(video_stream_->time_base) );
+#endif
                     video_frame_count++;
-                    std::clog << "Read " << video_frame_count << " frames, PTS: " << frame_pts << "\r" << std::flush;
+                    std::clog << "Read " << video_frame_count << " frames\r" << std::flush;
 
                     av_image_copy(
                         video_dst_data_, video_dst_linesize_,
-                        (const uint8_t **)(frame_->data), frame_->linesize,
-                        video_codec_context_->pix_fmt, video_codec_context_->width, video_codec_context_->height);
-                    
-                    video_image_->set_luma(video_dst_data_[0]);
-                    images_.push_back(*default_image_);
-                    copy(images_.back(), *video_image_);
+                                (const uint8_t **)(frame_->data), frame_->linesize,
+                                video_codec_context_->pix_fmt, video_codec_context_->width, video_codec_context_->height );
 
-                    if (sDebug)
-                        std::clog << "Copied frame " << video_frame_count << " to images_\n";
+                    // copy into image
+                    video_image_->set_luma( video_dst_data_[0] );
+
+                    images_.push_back( *default_image_ );
+                    copy( images_.back(), *video_image_ );
                 }
-
-                av_frame_unref(frame_);
+#ifdef VERBOSE
+                else
+                    std::clog << "." << std::flush;  //  We are skipping frames
+#endif
             }
         }
         else if (pkt->stream_index == ixa)
         {
             ret = avcodec_send_packet(audio_codec_context_, pkt);
             if (ret < 0) {
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                std::cerr << "Error sending audio packet for decoding: " << errbuf << std::endl;
-                return ret;
+                throw "Error sending audio packet for decoding";
             }
 
-            while (ret >= 0)
-            {
+            while (ret >= 0) {
                 ret = avcodec_receive_frame(audio_codec_context_, frame_);
-                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
-                {
+                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
                     break;
-                }
-                else if (ret < 0)
-                {
-                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                    std::cerr << "Error receiving decoded audio frame: " << errbuf << std::endl;
-                    return ret;
+                } else if (ret < 0) {
+                    throw "Error during audio decoding";
                 }
 
                 *got_frame = 1;
 
-                double frame_pts = frame_->pts * av_q2d(audio_stream_->time_base);
-                if (frame_pts >= first_frame_second_)
+#ifdef VERBOSE
+                std::clog << "AUDIO: " << frame_->pts*av_q2d(audio_stream_->time_base) << " sample count " << frame_->nb_samples << "\n";
+#endif
+                if (frame_->pts*av_q2d(audio_stream_->time_base)>=first_frame_second_)
                 {
+#ifdef VERBOSE
+                    std::clog << "USING AUDIO FRAME\n";
+#endif
+
                     if (!found_sound_)
                     {
                         found_sound_ = true;
-                        auto skip = frame_pts - first_frame_second_;
-                        if (skip > 0)
+                        auto skip = frame_->pts*av_q2d(audio_stream_->time_base)-first_frame_second_;
+                        if (skip>0)
                         {
                             std::clog << "Inserting " << skip << " seconds of silence\n";
-                            sound_->append_silence(skip);
+                            sound_->append_silence( skip );
                         }
                     }
-                    sound_->append_samples((float **)frame_->extended_data, frame_->nb_samples);
-                }
 
-                av_frame_unref(frame_);
+                    sound_->append_samples( (float **)frame_->extended_data, frame_->nb_samples );
+                }
             }
         }
 
-        return 0;
+        if (sDebug)
+            std::clog << "decode_packet returning " << decoded << "\n";
+
+        return decoded;
     }
 
 public:
     ffmpeg_reader() {}
 
-    ffmpeg_reader(const std::string &movie_path, double from, double duration)
+    ffmpeg_reader( const std::string &movie_path, double from, double duration )
     {
-        av_log_set_level(AV_LOG_WARNING);
+        av_log_set_level( AV_LOG_WARNING );
 
-        int ret = avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL);
-        if (ret != 0) {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("Cannot open input file: ") + errbuf);
-        }
+        //open video file
+        if (avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL) != 0)
+            throw "Cannot open input file";
 
-        ret = avformat_find_stream_info(format_context_, NULL);
-        if (ret < 0) {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("Cannot find stream information: ") + errbuf);
-        }
+        //get stream info
+        if (avformat_find_stream_info(format_context_, NULL) < 0)
+            throw "Cannot find stream information";
 
         if (sDebug)
             std::clog << "Searching for audio and video in " << format_context_->nb_streams << " streams\n";
 
-        ixv = av_find_best_stream(format_context_, AVMEDIA_TYPE_VIDEO, -1, -1, &video_decoder_, 0);
-        ixa = av_find_best_stream(format_context_, AVMEDIA_TYPE_AUDIO, -1, -1, &audio_decoder_, 0);
+        ixv = av_find_best_stream(format_context_,
+                                  AVMEDIA_TYPE_VIDEO,
+                                  -1,
+                                  -1,
+                                  &video_decoder_,
+                                  0);
+        ixa = av_find_best_stream(format_context_,
+                                  AVMEDIA_TYPE_AUDIO,
+                                  -1,
+                                  -1,
+                                  &audio_decoder_,
+                                  0);
 
-        if (ixv == AVERROR_STREAM_NOT_FOUND) {
-            throw std::runtime_error("NO VIDEO IN FILE");
+        if (ixv==AVERROR_STREAM_NOT_FOUND)
+        {
+            throw "NO VIDEO IN FILE\n";
         }
-        if (ixv == AVERROR_DECODER_NOT_FOUND) {
-            throw std::runtime_error("NO SUITABLE VIDEO DECODER AVAILABLE");
+        if (ixv==AVERROR_DECODER_NOT_FOUND)
+        {
+            throw "NO SUITABLE VIDEO DECODER AVAILABLE\n";
         }
-        if (ixa == AVERROR_STREAM_NOT_FOUND) {
+        if (ixa==AVERROR_STREAM_NOT_FOUND)
+        {
             std::cerr << "NO SOUND -- INSERTING SILENCE";
         }
-        if (ixa == AVERROR_DECODER_NOT_FOUND) {
-            throw std::runtime_error("NO SUITABLE AUDIO DECODER AVAILABLE");
+        if (ixa==AVERROR_DECODER_NOT_FOUND)
+        {
+            throw "NO SUITABLE AUDIO DECODER AVAILABLE\n";
         }
 
         if (sDebug)
@@ -256,92 +276,68 @@ public:
             std::clog << "Audio stream index :" << ixa << "\n";
         }
 
-        double seek_to = std::max(from - 10.0, 0.0);
-        ret = avformat_seek_file(format_context_, -1, seek_to * AV_TIME_BASE, seek_to * AV_TIME_BASE, seek_to * AV_TIME_BASE, AVSEEK_FLAG_ANY);
-        if (ret < 0) {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("CANNOT SEEK IN FILE: ") + errbuf);
-        }
+        double seek_to = std::max(from-10.0,0.0);    //  We seek to 10 seconds earlier, if we can
+        if (avformat_seek_file( format_context_, -1, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, AVSEEK_FLAG_ANY )<0)
+            throw "CANNOT SEEK IN FILE\n";
 
         video_stream_ = format_context_->streams[ixv];
-        audio_stream_ = ixa != AVERROR_STREAM_NOT_FOUND ? format_context_->streams[ixa] : nullptr;
+        audio_stream_ = ixa!=AVERROR_STREAM_NOT_FOUND?format_context_->streams[ixa]:nullptr;
 
         if (sDebug)
         {
-            std::clog << "Video : "
-                      << " " << video_stream_->codecpar->width << "x" << video_stream_->codecpar->height
-                      << "@" << av_q2d(video_stream_->r_frame_rate)
-                      << " fps"
-                      << " timebase:"
-                      << av_q2d(video_stream_->time_base)
-                      << "\n";
-            if (audio_stream_)
-            {
-                std::clog << "Audio : "
-                          << " " << audio_stream_->codecpar->sample_rate
-                          << "Hz \n";
-            }
+            std::clog   << "Video : "
+                        << " " << video_stream_->codecpar->width << "x" << video_stream_->codecpar->height
+                        << "@" << av_q2d( video_stream_->r_frame_rate )
+                        << " fps" 
+                        << " timebase:" 
+                        << av_q2d(video_stream_->time_base)
+                        << "\n";
+            std::clog   << "Audio : "
+                        << " " << audio_stream_->codecpar->sample_rate
+                        << "Hz \n";
         }
 
         first_frame_second_ = from;
-        frame_to_extract_ = duration * av_q2d(video_stream_->r_frame_rate);
+        frame_to_extract_ = duration*av_q2d( video_stream_->r_frame_rate );
 
-        video_codec_context_ = avcodec_alloc_context3(video_decoder_);
+        video_codec_context_ = avcodec_alloc_context3( video_decoder_ );
         if (!video_codec_context_)
-            throw std::runtime_error("CANNOT ALLOCATE VIDEO CODEC CONTEXT");
+            throw "CANNOT ALLOCATE VIDEO CODEC CONTEXT\n";
 
-        ret = avcodec_parameters_to_context(video_codec_context_, video_stream_->codecpar);
-        if (ret < 0) {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("FAILED TO COPY VIDEO CODEC PARAMETERS: ") + errbuf);
-        }
+        if (avcodec_parameters_to_context( video_codec_context_, video_stream_->codecpar ) < 0)
+            throw "FAILED TO COPY VIDEO CODEC PARAMETERS\n";
 
-        if (ixa != AVERROR_STREAM_NOT_FOUND)
+        if (ixa!=AVERROR_STREAM_NOT_FOUND)
         {
-            audio_codec_context_ = avcodec_alloc_context3(audio_decoder_);
+            audio_codec_context_ = avcodec_alloc_context3( audio_decoder_ );
             if (!audio_codec_context_)
-                throw std::runtime_error("CANNOT ALLOCATE AUDIO CODEC CONTEXT");
+                throw "CANNOT ALLOCATE AUDIO CODEC CONTEXT\n";
 
-            ret = avcodec_parameters_to_context(audio_codec_context_, audio_stream_->codecpar);
-            if (ret < 0) {
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                throw std::runtime_error(std::string("FAILED TO COPY AUDIO CODEC PARAMETERS: ") + errbuf);
-            }
+            if (avcodec_parameters_to_context( audio_codec_context_, audio_stream_->codecpar ) < 0)
+                throw "FAILED TO COPY AUDIO CODEC PARAMETERS\n";
         }
 
         AVDictionary *opts = NULL;
-        av_dict_set(&opts, "refcounted_frames", "0", 0);
 
-        ret = avcodec_open2(video_codec_context_, video_decoder_, &opts);
-        if (ret < 0) {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("CANNOT OPEN VIDEO CODEC: ") + errbuf);
-        }
+        av_dict_set(&opts, "refcounted_frames", "0", 0);    //  Do not refcount
 
-        if (ixa != AVERROR_STREAM_NOT_FOUND)
+        if (avcodec_open2( video_codec_context_, video_decoder_, &opts ) < 0)
+            throw "CANNOT OPEN VIDEO CODEC\n";
+        if (ixa!=AVERROR_STREAM_NOT_FOUND)
         {
-            ret = avcodec_open2(audio_codec_context_, audio_decoder_, nullptr);
-            if (ret < 0) {
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                throw std::runtime_error(std::string("CANNOT OPEN AUDIO CODEC: ") + errbuf);
-            }
-
+            if (avcodec_open2( audio_codec_context_, audio_decoder_, nullptr ) < 0)
+                throw "CANNOT OPEN AUDIO CODEC\n";
             if (sDebug)
-                std::clog << "AUDIO CODEC: " << avcodec_get_name(audio_codec_context_->codec_id) << "\n";
+                std::clog << "AUDIO CODEC: " << avcodec_get_name( audio_codec_context_->codec_id ) << "\n";
 
             AVSampleFormat sfmt = audio_codec_context_->sample_fmt;
             int n_channels = audio_codec_context_->ch_layout.nb_channels;
 
             if (sDebug)
             {
-                std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
+                std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
                 std::clog << "# CHANNELS   :" << n_channels << "\n";
-                std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt) ? "YES" : "NO") << "\n";
+                std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt)?"YES":"NO") << "\n";
             }
 
             if (av_sample_fmt_is_planar(sfmt))
@@ -350,11 +346,11 @@ public:
 
                 if (sDebug)
                 {
-                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
+                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
                     std::clog << "SAMPLE RATE  :" << audio_codec_context_->sample_rate << "\n";
                 }
             }
-            sound_ = std::make_unique<sound_buffer>(n_channels, audio_codec_context_->sample_rate);
+            sound_ = std::make_unique<sound_buffer>( n_channels, audio_codec_context_->sample_rate );
         }
         else
             sound_ = nullptr;
@@ -362,73 +358,72 @@ public:
         if (sDebug)
             std::clog << "VIDEO CODEC OPENED WITH PIXEL FORMAT " << av_get_pix_fmt_name(video_codec_context_->pix_fmt) << "\n";
 
-        if (video_codec_context_->pix_fmt != AV_PIX_FMT_YUV420P)
-            throw std::runtime_error("WAS EXPECTING A YUV420P PIXEL FORMAT");
+        if (video_codec_context_->pix_fmt!=AV_PIX_FMT_YUV420P)
+            throw "WAS EXPECTING A YUV240P PIXEL FORMAT";
 
-        int bufsize = av_image_alloc(
+        auto bufsize = av_image_alloc(
             video_dst_data_,
             video_dst_linesize_,
             video_codec_context_->width,
             video_codec_context_->height,
             video_codec_context_->pix_fmt,
-            1);
+            1 );
 
-        if (bufsize < 0)
+        if (bufsize<0)
+            throw "CANNOT ALLOCATE IMAGE\n";
+
+        video_image_ = std::make_unique<image>( video_codec_context_->width, video_codec_context_->height );
+
+        double aspect = video_codec_context_->width/(double)video_codec_context_->height;
+        if (aspect>512/342.0)
         {
-            char errbuf[AV_ERROR_MAX_STRING_SIZE];
-            av_strerror(bufsize, errbuf, AV_ERROR_MAX_STRING_SIZE);
-            throw std::runtime_error(std::string("CANNOT ALLOCATE IMAGE: ") + errbuf);
-        }
-
-        video_image_ = std::make_unique<image>(video_codec_context_->width, video_codec_context_->height);
-
-        double aspect = video_codec_context_->width / (double)video_codec_context_->height;
-        if (aspect > 512 / 342.0)
-        {
-            default_image_ = std::make_unique<image>(342 * aspect, 342);
+            default_image_ = std::make_unique<image>( 342*aspect, 342 );
         }
         else
         {
-            default_image_ = std::make_unique<image>(512, 512 / aspect);
+            default_image_ = std::make_unique<image>( 512, 512/aspect );
         }
 
         if (sDebug)
         {
             std::clog << "Image structure:\n";
             std::clog << video_dst_linesize_[0] << " " << video_dst_linesize_[1] << " " << video_dst_linesize_[2] << " " << video_dst_linesize_[3] << "\n";
-            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + video_dst_linesize_[2] + video_dst_linesize_[3]) * video_codec_context_->height << "\n";
+            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + video_dst_linesize_[2] + video_dst_linesize_[3])*video_codec_context_->height << "\n";
             std::clog << bufsize << "\n";
         }
 
         frame_ = av_frame_alloc();
-        if (!frame_)
-            throw std::runtime_error("Could not allocate frame");
 
+        // Allocate packet
         pkt_ = av_packet_alloc();
         if (!pkt_)
-            throw std::runtime_error("Could not allocate packet");
+            throw "Failed to allocate packet";
 
         int got_frame = 0;
 
         while (av_read_frame(format_context_, pkt_) >= 0)
         {
-            do
-            {
+            do {
                 auto ret = decode_packet(&got_frame, pkt_);
-                if (images_.size() >= frame_to_extract_)
+                if (images_.size() == frame_to_extract_)
                     goto end;
                 if (ret < 0)
                     break;
+                pkt_->data += ret;
+                pkt_->size -= ret;
             } while (pkt_->size > 0);
             av_packet_unref(pkt_);
         }
 
-        // Flush the decoders
-        pkt_->data = NULL;
-        pkt_->size = 0;
-        do {
-            decode_packet(&got_frame, pkt_);
-        } while (got_frame);
+        /* flush cached frames */
+        if (images_.size() != frame_to_extract_)
+        {
+            pkt_->data = NULL;
+            pkt_->size = 0;
+            do {
+                decode_packet(&got_frame, pkt_);
+            } while (got_frame);
+        }
 
     end:
         std::clog << "\n";
@@ -436,9 +431,9 @@ public:
         image_ix = 0;
 
         if (sDebug)
-            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of " << images_.size() / av_q2d(video_stream_->r_frame_rate) << " seconds \n";
+            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of " << images_.size()/av_q2d( video_stream_->r_frame_rate ) << " seconds \n";
 
-        if (ixa != AVERROR_STREAM_NOT_FOUND && sound_)
+        if (ixa != AVERROR_STREAM_NOT_FOUND)
         {
             sound_->process();
             sound_ix = 0;
@@ -451,44 +446,37 @@ public:
     ~ffmpeg_reader()
     {
         avformat_close_input(&format_context_);
-        if (sDebug)
-            std::clog << "Closed media file\n";
-        if (video_codec_context_)
-            avcodec_free_context(&video_codec_context_);
+        avcodec_free_context(&video_codec_context_);
         if (audio_codec_context_)
             avcodec_free_context(&audio_codec_context_);
-        if (frame_)
-            av_frame_free(&frame_);
-        if (pkt_)
-            av_packet_free(&pkt_);
-        if (video_dst_data_[0])
-            av_freep(&video_dst_data_[0]);
+        av_frame_free(&frame_);
+        av_packet_free(&pkt_);
+        av_freep(&video_dst_data_[0]);
+        if (sDebug)
+            std::clog << "Closed media file\n";
     }
 
-    virtual double frame_rate() override
+    virtual double frame_rate()
     {
         return av_q2d(video_stream_->r_frame_rate);
     }
 
-    virtual std::unique_ptr<image> next() override
+    virtual std::unique_ptr<image> next()
     {
-        if (sDebug) std::clog << "next() called, image_ix: " << image_ix << ", images_.size(): " << images_.size() << std::endl;
-        
-        if (image_ix == -1 || image_ix >= (int)images_.size())
-        {
-            if (sDebug) std::clog << "next() returning nullptr" << std::endl;
+        if (image_ix == -1)
             return nullptr;
-        }
+        if (image_ix == (int)images_.size())
+            return nullptr;
         auto res = std::make_unique<image>(images_[image_ix]);
         image_ix++;
-        if (sDebug) std::clog << "next() returning image, new image_ix: " << image_ix << std::endl;
         return res;
     }
 
-    virtual std::unique_ptr<sound_frame_t> next_sound() override
+    virtual std::unique_ptr<sound_frame_t> next_sound()
     {
-        if (ixa != AVERROR_STREAM_NOT_FOUND && sound_)
+        if (ixa != AVERROR_STREAM_NOT_FOUND)
         {
+            auto s = std::make_unique<sound_frame_t>();
             return sound_->extract(sound_ix++);
         }
         return nullptr;
@@ -499,11 +487,11 @@ std::unique_ptr<input_reader> make_ffmpeg_reader(const std::string &movie_path, 
 {
     try
     {
-        return std::make_unique<ffmpeg_reader>(movie_path, from, to - from);
+        return std::make_unique<ffmpeg_reader>(movie_path, from, to);
     }
-    catch (const std::exception& e)
+    catch (const char *e)
     {
-        std::cerr << "**** ERROR: " << e.what() << std::endl;
+        std::clog << "**** ERROR : " << e << "\n";
         return nullptr;
     }
 }

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1,11 +1,11 @@
 #include "reader.hpp"
 
 extern "C" {
-#include <libavformat/avformat.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/samplefmt.h>
-#include <libavutil/timestamp.h>
-#include <libavcodec/avcodec.h>
+    #include <libavformat/avformat.h>
+    #include <libavutil/imgutils.h>
+    #include <libavutil/samplefmt.h>
+    #include <libavutil/timestamp.h>
+    #include <libavcodec/avcodec.h>
 }
 
 #include <array>
@@ -13,376 +13,354 @@ extern "C" {
 extern bool sDebug;
 
 /// This stores a sound buffer and transform it into a suitable format for flims
-class sound_buffer
-{
+class sound_buffer {
     std::vector<float> data_;
-
     size_t channel_count_ = 0;      //  # of channels
     size_t sample_rate_ = 0;        //  # of samples per second
-
     float min_sample_;
     float max_sample_;
 
 public:
-    sound_buffer( size_t channel_count, size_t sample_rate ) :
+    sound_buffer(size_t channel_count, size_t sample_rate) :
         channel_count_{channel_count},
-        sample_rate_ {sample_rate}
+        sample_rate_{sample_rate}
     {}
 
-    //  Append silence
-    void append_silence( float duration )
-    {
+    void append_silence(float duration) {
         size_t sample_count = sample_rate_ * duration;
-        for (size_t i=0;i!=sample_count;i++)
-        {
-            data_.push_back( 0 );
+        for (size_t i = 0; i != sample_count; i++) {
+            data_.push_back(0);
         }
     }
 
-    //  Append sample_count samples over each of the channels
-    void append_samples( float **samples, size_t sample_count )
-    {
-        for (size_t i=0;i!=sample_count;i++)
-        {
+    void append_samples(float **samples, size_t sample_count) {
+        for (size_t i = 0; i != sample_count; i++) {
             float v = 0;
-            for (size_t j=0;j!=channel_count_;j++)
+            for (size_t j = 0; j != channel_count_; j++) {
                 v += samples[j][i];
-
-            data_.push_back( v/channel_count_ );
+            }
+            data_.push_back(v / channel_count_);
         }
     }
 
-    void process()
-    {
-        min_sample_ = *std::min_element( std::begin(data_), std::end(data_) );
-        max_sample_ = *std::max_element( std::begin(data_), std::end(data_) );
+    void process() {
+        min_sample_ = *std::min_element(std::begin(data_), std::end(data_));
+        max_sample_ = *std::max_element(std::begin(data_), std::end(data_));
     }
 
-    //  Extract a 370 bytes frames (1/60th of a second)
-    std::unique_ptr<sound_frame_t> extract( size_t frame )
-    {
+    std::unique_ptr<sound_frame_t> extract(size_t frame) {
         double t = frame / 60.0;        //  Time in seconds
         size_t start = t * sample_rate_;
 
-        if (start>=data_.size())
+        if (start >= data_.size()) {
             return nullptr;
+        }
 
         auto fr = std::make_unique<sound_frame_t>();
 
-        for (int i=0;i!=sound_frame_t::size;i++)
-        {
-            size_t index = start+(i/370.0/60.0)*sample_rate_;
-            if (index<data_.size())
-                fr->at(i) = (data_[index]-min_sample_)/(max_sample_-min_sample_)*255;
-            else
+        for (int i = 0; i != sound_frame_t::size; i++) {
+            size_t index = start + (i / 370.0 / 60.0) * sample_rate_;
+            if (index < data_.size()) {
+                fr->at(i) = (data_[index] - min_sample_) / (max_sample_ - min_sample_) * 255;
+            } else {
                 fr->at(i) = 128;
+            }
         }
 
         return fr;
     }
 };
 
-class ffmpeg_reader : public input_reader
-{
+class ffmpeg_reader : public input_reader {
     AVFormatContext *format_context_ = nullptr;
     const AVCodec *video_decoder_;
     const AVCodec *audio_decoder_;
     AVStream *video_stream_;
     AVStream *audio_stream_;
-
     AVCodecContext *video_codec_context_;
     AVCodecContext *audio_codec_context_;
-
     uint8_t *video_dst_data_[4] = {NULL};
     int video_dst_linesize_[4];
-
     AVPacket *pkt_;
     AVFrame *frame_;
-
     int ixv;    //  Video frame index
     int ixa;    //  Audio frame index
-
     size_t video_frame_count = 0;
-
     std::unique_ptr<image> video_image_;        //  Size of the video input
     std::unique_ptr<image> default_image_;      //  Size of our output
-
     std::vector<image> images_;
-
     std::unique_ptr<sound_buffer> sound_;
-
     int image_ix = -1;
     int sound_ix = -1;
-
     double first_frame_second_;
     size_t frame_to_extract_;
-
     bool found_sound_ = false;                   //  To track if sounds starts with an offset
 
-    int decode_packet(int *got_frame, AVPacket *pkt)
-    {
-        int ret = 0;
+    int decode_video_packet(int *got_frame, AVPacket *pkt) {
+        int ret = avcodec_send_packet(video_codec_context_, pkt);
+        if (ret < 0) {
+            if (ret == AVERROR_EOF) {
+                return 0;
+            }
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            std::cerr << "Error sending video packet for decoding: " << errbuf << std::endl;
+            return ret;
+        }
+
+        while (ret >= 0) {
+            ret = avcodec_receive_frame(video_codec_context_, frame_);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                break;
+            } else if (ret < 0) {
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                std::cerr << "Error during video decoding: " << errbuf << std::endl;
+                return ret;
+            }
+
+            *got_frame = 1;
+
+            #ifdef VERBOSE
+            std::clog << "VIDEO FRAME TS = " << frame_->pts * av_q2d(video_stream_->time_base) << "\n";
+            #endif
+
+            if (frame_->pts * av_q2d(video_stream_->time_base) >= first_frame_second_ && 
+                images_.size() <= video_frame_count) {
+                #ifdef VERBOSE
+                printf("video_frame%s n:%d coded_n:%d presentation_ts:%ld / %f\n",
+                    cached ? "(cached)" : "",
+                    video_frame_count, frame_->coded_picture_number, frame_->pts, 
+                    frame_->pts * av_q2d(video_stream_->time_base));
+                #endif
+                video_frame_count++;
+                std::clog << "Read " << video_frame_count << " frames\r" << std::flush;
+
+                av_image_copy(
+                    video_dst_data_, video_dst_linesize_,
+                    (const uint8_t **)(frame_->data), frame_->linesize,
+                    video_codec_context_->pix_fmt, video_codec_context_->width, 
+                    video_codec_context_->height);
+
+                video_image_->set_luma(video_dst_data_[0]);
+
+                images_.push_back(*default_image_);
+                copy(images_.back(), *video_image_);
+            }
+            #ifdef VERBOSE
+            else {
+                std::clog << "." << std::flush;  //  We are skipping frames
+            }
+            #endif
+        }
+
+        return 0;
+    }
+
+    int decode_audio_packet(int *got_frame, AVPacket *pkt) {
+        int ret = avcodec_send_packet(audio_codec_context_, pkt);
+        if (ret < 0) {
+            if (ret == AVERROR_EOF) {
+                return 0;
+            }
+            char errbuf[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+            std::cerr << "Error sending audio packet for decoding: " << errbuf << std::endl;
+            return ret;
+        }
+
+        while (ret >= 0) {
+            ret = avcodec_receive_frame(audio_codec_context_, frame_);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+                break;
+            } else if (ret < 0) {
+                char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                std::cerr << "Error during audio decoding: " << errbuf << std::endl;
+                return ret;
+            }
+
+            *got_frame = 1;
+
+            #ifdef VERBOSE
+            std::clog << "AUDIO: " << frame_->pts * av_q2d(audio_stream_->time_base) 
+                      << " sample count " << frame_->nb_samples << "\n";
+            #endif
+
+            if (frame_->pts * av_q2d(audio_stream_->time_base) >= first_frame_second_) {
+                #ifdef VERBOSE
+                std::clog << "USING AUDIO FRAME\n";
+                #endif
+
+                if (!found_sound_) {
+                    found_sound_ = true;
+                    auto skip = frame_->pts * av_q2d(audio_stream_->time_base) - first_frame_second_;
+                    if (skip > 0) {
+                        std::clog << "Inserting " << skip << " seconds of silence\n";
+                        sound_->append_silence(skip);
+                    }
+                }
+
+                sound_->append_samples((float **)frame_->extended_data, frame_->nb_samples);
+            }
+        }
+
+        return 0;
+    }
+
+    int decode_packet(int *got_frame, AVPacket *pkt) {
         int decoded = pkt->size;
         *got_frame = 0;
 
-        if (pkt->stream_index == ixv)
-        {
-            /* decode video frame */
-            ret = avcodec_send_packet(video_codec_context_, pkt);
-            if (ret < 0) {
-                if (ret == AVERROR_EOF) {
-                    // End of file, not an error in this case
-                    return 0;
-                }
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                std::cerr << "Error sending video packet for decoding: " << errbuf << std::endl;
-                return ret;
-            }
-
-            while (ret >= 0) {
-                ret = avcodec_receive_frame(video_codec_context_, frame_);
-                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-                    break;
-                } else if (ret < 0) {
-                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                    std::cerr << "Error during video decoding: " << errbuf << std::endl;
-                    return ret;
-                }
-
-                *got_frame = 1;
-
-#ifdef VERBOSE
-                std::clog << "VIDEO FRAME TS = " << frame_->pts*av_q2d(video_stream_->time_base) << "\n";
-#endif
-
-                if (frame_->pts*av_q2d(video_stream_->time_base)>=first_frame_second_ && images_.size()<=video_frame_count)
-                {
-#ifdef VERBOSE
-                    printf("video_frame%s n:%d coded_n:%d presentation_ts:%ld / %f\n",
-                        cached ? "(cached)" : "",
-                        video_frame_count, frame_->coded_picture_number, frame_->pts, frame_->pts*av_q2d(video_stream_->time_base) );
-#endif
-                    video_frame_count++;
-                    std::clog << "Read " << video_frame_count << " frames\r" << std::flush;
-
-                    av_image_copy(
-                        video_dst_data_, video_dst_linesize_,
-                                (const uint8_t **)(frame_->data), frame_->linesize,
-                                video_codec_context_->pix_fmt, video_codec_context_->width, video_codec_context_->height );
-
-                    // copy into image
-                    video_image_->set_luma( video_dst_data_[0] );
-
-                    images_.push_back( *default_image_ );
-                    copy( images_.back(), *video_image_ );
-                }
-#ifdef VERBOSE
-                else
-                    std::clog << "." << std::flush;  //  We are skipping frames
-#endif
-            }
-        }
-        else if (pkt->stream_index == ixa)
-        {
-            ret = avcodec_send_packet(audio_codec_context_, pkt);
-            if (ret < 0) {
-                if (ret == AVERROR_EOF) {
-                    // End of file, not an error in this case
-                    return 0;
-                }
-                char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                std::cerr << "Error sending audio packet for decoding: " << errbuf << std::endl;
-                return ret;
-            }
-
-            while (ret >= 0) {
-                ret = avcodec_receive_frame(audio_codec_context_, frame_);
-                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-                    break;
-                } else if (ret < 0) {
-                    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-                    av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
-                    std::cerr << "Error during audio decoding: " << errbuf << std::endl;
-                    return ret;
-                }
-
-                *got_frame = 1;
-
-#ifdef VERBOSE
-                std::clog << "AUDIO: " << frame_->pts*av_q2d(audio_stream_->time_base) << " sample count " << frame_->nb_samples << "\n";
-#endif
-                if (frame_->pts*av_q2d(audio_stream_->time_base)>=first_frame_second_)
-                {
-#ifdef VERBOSE
-                    std::clog << "USING AUDIO FRAME\n";
-#endif
-
-                    if (!found_sound_)
-                    {
-                        found_sound_ = true;
-                        auto skip = frame_->pts*av_q2d(audio_stream_->time_base)-first_frame_second_;
-                        if (skip>0)
-                        {
-                            std::clog << "Inserting " << skip << " seconds of silence\n";
-                            sound_->append_silence( skip );
-                        }
-                    }
-
-                    sound_->append_samples( (float **)frame_->extended_data, frame_->nb_samples );
-                }
-            }
+        if (pkt->stream_index == ixv) {
+            decode_video_packet(got_frame, pkt);
+        } else if (pkt->stream_index == ixa) {
+            decode_audio_packet(got_frame, pkt);
         }
 
         return decoded;
     }
 
+    void init_video_context() {
+        video_codec_context_ = avcodec_alloc_context3(video_decoder_);
+        if (!video_codec_context_) {
+            throw "CANNOT ALLOCATE VIDEO CODEC CONTEXT";
+        }
+
+        if (avcodec_parameters_to_context(video_codec_context_, video_stream_->codecpar) < 0) {
+            throw "FAILED TO COPY VIDEO CODEC PARAMETERS";
+        }
+
+        AVDictionary *opts = NULL;
+        av_dict_set(&opts, "refcounted_frames", "0", 0);    //  Do not refcount
+
+        if (avcodec_open2(video_codec_context_, video_decoder_, &opts) < 0) {
+            throw "CANNOT OPEN VIDEO CODEC";
+        }
+
+        if (sDebug) {
+            std::clog << "VIDEO CODEC OPENED WITH PIXEL FORMAT " 
+                      << av_get_pix_fmt_name(video_codec_context_->pix_fmt) << "\n";
+        }
+
+        if (video_codec_context_->pix_fmt != AV_PIX_FMT_YUV420P) {
+            throw "WAS EXPECTING A YUV420P PIXEL FORMAT";
+        }
+    }
+
+    void init_audio_context() {
+        if (ixa != AVERROR_STREAM_NOT_FOUND) {
+            audio_codec_context_ = avcodec_alloc_context3(audio_decoder_);
+            if (!audio_codec_context_) {
+                throw "CANNOT ALLOCATE AUDIO CODEC CONTEXT";
+            }
+
+            if (avcodec_parameters_to_context(audio_codec_context_, audio_stream_->codecpar) < 0) {
+                throw "FAILED TO COPY AUDIO CODEC PARAMETERS";
+            }
+
+            if (avcodec_open2(audio_codec_context_, audio_decoder_, nullptr) < 0) {
+                throw "CANNOT OPEN AUDIO CODEC";
+            }
+
+            if (sDebug) {
+                std::clog << "AUDIO CODEC: " << avcodec_get_name(audio_codec_context_->codec_id) << "\n";
+            }
+
+            AVSampleFormat sfmt = audio_codec_context_->sample_fmt;
+            int n_channels = audio_codec_context_->ch_layout.nb_channels;
+
+            if (sDebug) {
+                std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
+                std::clog << "# CHANNELS   :" << n_channels << "\n";
+                std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt) ? "YES" : "NO") << "\n";
+            }
+
+            if (av_sample_fmt_is_planar(sfmt)) {
+                sfmt = av_get_packed_sample_fmt(sfmt);
+
+                if (sDebug) {
+                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name(sfmt) << "\n";
+                    std::clog << "SAMPLE RATE  :" << audio_codec_context_->sample_rate << "\n";
+                }
+            }
+            sound_ = std::make_unique<sound_buffer>(n_channels, audio_codec_context_->sample_rate);
+        } else {
+            sound_ = nullptr;
+        }
+    }
+
 public:
     ffmpeg_reader() {}
 
-    ffmpeg_reader( const std::string &movie_path, double from, double duration )
-    {
-        av_log_set_level( AV_LOG_WARNING );
+    ffmpeg_reader(const std::string &movie_path, double from, double duration) {
+        av_log_set_level(AV_LOG_WARNING);
 
-        //open video file
-        if (avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL) != 0)
+        if (avformat_open_input(&format_context_, movie_path.c_str(), NULL, NULL) != 0) {
             throw "Cannot open input file";
+        }
 
-        //get stream info
-        if (avformat_find_stream_info(format_context_, NULL) < 0)
+        if (avformat_find_stream_info(format_context_, NULL) < 0) {
             throw "Cannot find stream information";
+        }
 
-        if (sDebug)
+        if (sDebug) {
             std::clog << "Searching for audio and video in " << format_context_->nb_streams << " streams\n";
-
-        ixv = av_find_best_stream(format_context_,
-                                  AVMEDIA_TYPE_VIDEO,
-                                  -1,
-                                  -1,
-                                  &video_decoder_,
-                                  0);
-        ixa = av_find_best_stream(format_context_,
-                                  AVMEDIA_TYPE_AUDIO,
-                                  -1,
-                                  -1,
-                                  &audio_decoder_,
-                                  0);
-
-        if (ixv==AVERROR_STREAM_NOT_FOUND)
-        {
-            throw "NO VIDEO IN FILE\n";
         }
-        if (ixv==AVERROR_DECODER_NOT_FOUND)
-        {
-            throw "NO SUITABLE VIDEO DECODER AVAILABLE\n";
+
+        ixv = av_find_best_stream(format_context_, AVMEDIA_TYPE_VIDEO, -1, -1, &video_decoder_, 0);
+        ixa = av_find_best_stream(format_context_, AVMEDIA_TYPE_AUDIO, -1, -1, &audio_decoder_, 0);
+
+        if (ixv == AVERROR_STREAM_NOT_FOUND) {
+            throw "NO VIDEO IN FILE";
         }
-        if (ixa==AVERROR_STREAM_NOT_FOUND)
-        {
+        if (ixv == AVERROR_DECODER_NOT_FOUND) {
+            throw "NO SUITABLE VIDEO DECODER AVAILABLE";
+        }
+        if (ixa == AVERROR_STREAM_NOT_FOUND) {
             std::cerr << "NO SOUND -- INSERTING SILENCE";
         }
-        if (ixa==AVERROR_DECODER_NOT_FOUND)
-        {
-            throw "NO SUITABLE AUDIO DECODER AVAILABLE\n";
+        if (ixa == AVERROR_DECODER_NOT_FOUND) {
+            throw "NO SUITABLE AUDIO DECODER AVAILABLE";
         }
 
-        if (sDebug)
-        {
+        if (sDebug) {
             std::clog << "Video stream index :" << ixv << "\n";
             std::clog << "Audio stream index :" << ixa << "\n";
         }
 
         double actual_duration = format_context_->duration / (double)AV_TIME_BASE;
         if (duration > actual_duration) {
-            std::clog << "Warning: Requested duration (" << duration << "s) exceeds video length (" << actual_duration << "s). Trimming to video length.\n";
+            std::clog << "Warning: Requested duration (" << duration << "s) exceeds video length (" 
+                      << actual_duration << "s). Trimming to video length.\n";
             duration = actual_duration;
         }
 
-        double seek_to = std::max(from-10.0,0.0);    //  We seek to 10 seconds earlier, if we can
-        if (avformat_seek_file( format_context_, -1, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, seek_to*AV_TIME_BASE, AVSEEK_FLAG_ANY )<0)
-            throw "CANNOT SEEK IN FILE\n";
+        double seek_to = std::max(from - 10.0, 0.0);    //  We seek to 10 seconds earlier, if we can
+        if (avformat_seek_file(format_context_, -1, seek_to * AV_TIME_BASE, 
+                               seek_to * AV_TIME_BASE, seek_to * AV_TIME_BASE, 
+                               AVSEEK_FLAG_ANY) < 0) {
+            throw "CANNOT SEEK IN FILE";
+        }
 
         video_stream_ = format_context_->streams[ixv];
-        audio_stream_ = ixa!=AVERROR_STREAM_NOT_FOUND?format_context_->streams[ixa]:nullptr;
+        audio_stream_ = ixa != AVERROR_STREAM_NOT_FOUND ? format_context_->streams[ixa] : nullptr;
 
-        if (sDebug)
-        {
-            std::clog   << "Video : "
-                        << " " << video_stream_->codecpar->width << "x" << video_stream_->codecpar->height
-                        << "@" << av_q2d( video_stream_->r_frame_rate )
-                        << " fps" 
-                        << " timebase:" 
-                        << av_q2d(video_stream_->time_base)
-                        << "\n";
-            std::clog   << "Audio : "
-                        << " " << audio_stream_->codecpar->sample_rate
-                        << "Hz \n";
+        if (sDebug) {
+            std::clog << "Video : " << video_stream_->codecpar->width << "x"
+                      << video_stream_->codecpar->height << "@"
+                      << av_q2d(video_stream_->r_frame_rate) << " fps"
+                      << " timebase:" << av_q2d(video_stream_->time_base) << "\n";
+            if (audio_stream_) {
+                std::clog << "Audio : " << audio_stream_->codecpar->sample_rate << "Hz \n";
+            }
         }
 
         first_frame_second_ = from;
-        frame_to_extract_ = duration*av_q2d( video_stream_->r_frame_rate );
+        frame_to_extract_ = duration * av_q2d(video_stream_->r_frame_rate);
 
-        video_codec_context_ = avcodec_alloc_context3( video_decoder_ );
-        if (!video_codec_context_)
-            throw "CANNOT ALLOCATE VIDEO CODEC CONTEXT\n";
-
-        if (avcodec_parameters_to_context( video_codec_context_, video_stream_->codecpar ) < 0)
-            throw "FAILED TO COPY VIDEO CODEC PARAMETERS\n";
-
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
-        {
-            audio_codec_context_ = avcodec_alloc_context3( audio_decoder_ );
-            if (!audio_codec_context_)
-                throw "CANNOT ALLOCATE AUDIO CODEC CONTEXT\n";
-
-            if (avcodec_parameters_to_context( audio_codec_context_, audio_stream_->codecpar ) < 0)
-                throw "FAILED TO COPY AUDIO CODEC PARAMETERS\n";
-        }
-
-        AVDictionary *opts = NULL;
-
-        av_dict_set(&opts, "refcounted_frames", "0", 0);    //  Do not refcount
-
-        if (avcodec_open2( video_codec_context_, video_decoder_, &opts ) < 0)
-            throw "CANNOT OPEN VIDEO CODEC\n";
-        if (ixa!=AVERROR_STREAM_NOT_FOUND)
-        {
-            if (avcodec_open2( audio_codec_context_, audio_decoder_, nullptr ) < 0)
-                throw "CANNOT OPEN AUDIO CODEC\n";
-            if (sDebug)
-                std::clog << "AUDIO CODEC: " << avcodec_get_name( audio_codec_context_->codec_id ) << "\n";
-
-            AVSampleFormat sfmt = audio_codec_context_->sample_fmt;
-            int n_channels = audio_codec_context_->ch_layout.nb_channels;
-
-            if (sDebug)
-            {
-                std::clog << "SAMPLE FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
-                std::clog << "# CHANNELS   :" << n_channels << "\n";
-                std::clog << "PLANAR       :" << (av_sample_fmt_is_planar(sfmt)?"YES":"NO") << "\n";
-            }
-
-            if (av_sample_fmt_is_planar(sfmt))
-            {
-                sfmt = av_get_packed_sample_fmt(sfmt);
-
-                if (sDebug)
-                {
-                    std::clog << "PACKED FORMAT:" << av_get_sample_fmt_name( sfmt ) << "\n";
-                    std::clog << "SAMPLE RATE  :" << audio_codec_context_->sample_rate << "\n";
-                }
-            }
-            sound_ = std::make_unique<sound_buffer>( n_channels, audio_codec_context_->sample_rate );
-        }
-        else
-            sound_ = nullptr;
-
-        if (sDebug)
-            std::clog << "VIDEO CODEC OPENED WITH PIXEL FORMAT " << av_get_pix_fmt_name(video_codec_context_->pix_fmt) << "\n";
-
-        if (video_codec_context_->pix_fmt!=AV_PIX_FMT_YUV420P)
-            throw "WAS EXPECTING A YUV420P PIXEL FORMAT";
+        init_video_context();
+        init_audio_context();
 
         auto bufsize = av_image_alloc(
             video_dst_data_,
@@ -390,46 +368,46 @@ public:
             video_codec_context_->width,
             video_codec_context_->height,
             video_codec_context_->pix_fmt,
-            1 );
+            1);
 
-        if (bufsize<0)
-            throw "CANNOT ALLOCATE IMAGE\n";
-
-        video_image_ = std::make_unique<image>( video_codec_context_->width, video_codec_context_->height );
-
-        double aspect = video_codec_context_->width/(double)video_codec_context_->height;
-        if (aspect>512/342.0)
-        {
-            default_image_ = std::make_unique<image>( 342*aspect, 342 );
-        }
-        else
-        {
-            default_image_ = std::make_unique<image>( 512, 512/aspect );
+        if (bufsize < 0) {
+            throw "CANNOT ALLOCATE IMAGE";
         }
 
-        if (sDebug)
-        {
+        video_image_ = std::make_unique<image>(video_codec_context_->width, video_codec_context_->height);
+
+        double aspect = video_codec_context_->width / (double)video_codec_context_->height;
+        if (aspect > 512 / 342.0) {
+            default_image_ = std::make_unique<image>(342 * aspect, 342);
+        } else {
+            default_image_ = std::make_unique<image>(512, 512 / aspect);
+        }
+
+        if (sDebug) {
             std::clog << "Image structure:\n";
-            std::clog << video_dst_linesize_[0] << " " << video_dst_linesize_[1] << " " << video_dst_linesize_[2] << " " << video_dst_linesize_[3] << "\n";
-            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + video_dst_linesize_[2] + video_dst_linesize_[3])*video_codec_context_->height << "\n";
+            std::clog << video_dst_linesize_[0] << " " << video_dst_linesize_[1] << " "
+                      << video_dst_linesize_[2] << " " << video_dst_linesize_[3] << "\n";
+            std::clog << (video_dst_linesize_[0] + video_dst_linesize_[1] + 
+                          video_dst_linesize_[2] + video_dst_linesize_[3]) * 
+                          video_codec_context_->height << "\n";
             std::clog << bufsize << "\n";
         }
 
         frame_ = av_frame_alloc();
 
-        // Allocate packet
         pkt_ = av_packet_alloc();
-        if (!pkt_)
+        if (!pkt_) {
             throw "Failed to allocate packet";
+        }
 
         int got_frame = 0;
 
-        while (av_read_frame(format_context_, pkt_) >= 0 && images_.size() < frame_to_extract_)
-        {
+        while (av_read_frame(format_context_, pkt_) >= 0 && images_.size() < frame_to_extract_) {
             do {
                 auto ret = decode_packet(&got_frame, pkt_);
-                if (ret < 0)
+                if (ret < 0) {
                     break;
+                }
                 pkt_->data += ret;
                 pkt_->size -= ret;
             } while (pkt_->size > 0);
@@ -437,8 +415,7 @@ public:
         }
 
         /* flush cached frames */
-        if (images_.size() != frame_to_extract_)
-        {
+        if (images_.size() != frame_to_extract_) {
             pkt_->data = NULL;
             pkt_->size = 0;
             do {
@@ -450,67 +427,60 @@ public:
 
         image_ix = 0;
 
-        if (sDebug)
-            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of " << images_.size()/av_q2d( video_stream_->r_frame_rate ) << " seconds \n";
+        if (sDebug) {
+            std::clog << "\nAcquired " << images_.size() << " frames of video for a total of "
+                      << images_.size() / av_q2d(video_stream_->r_frame_rate) << " seconds \n";
+        }
 
-        if (ixa != AVERROR_STREAM_NOT_FOUND)
-        {
+        if (ixa != AVERROR_STREAM_NOT_FOUND) {
             sound_->process();
             sound_ix = 0;
         }
 
-        if (sDebug)
+        if (sDebug) {
             std::clog << "\n";
+        }
     }
 
-    ~ffmpeg_reader()
-    {
+    ~ffmpeg_reader() {
         avformat_close_input(&format_context_);
         avcodec_free_context(&video_codec_context_);
-        if (audio_codec_context_)
+        if (audio_codec_context_) {
             avcodec_free_context(&audio_codec_context_);
+        }
         av_frame_free(&frame_);
         av_packet_free(&pkt_);
         av_freep(&video_dst_data_[0]);
-        if (sDebug)
+        if (sDebug) {
             std::clog << "Closed media file\n";
+        }
     }
 
-    virtual double frame_rate()
-    {
+    virtual double frame_rate() {
         return av_q2d(video_stream_->r_frame_rate);
     }
 
-    virtual std::unique_ptr<image> next()
-    {
-        if (image_ix == -1)
+    virtual std::unique_ptr<image> next() {
+        if (image_ix == -1 || image_ix == (int)images_.size()) {
             return nullptr;
-        if (image_ix == (int)images_.size())
-            return nullptr;
+        }
         auto res = std::make_unique<image>(images_[image_ix]);
         image_ix++;
         return res;
     }
 
-    virtual std::unique_ptr<sound_frame_t> next_sound()
-    {
-        if (ixa != AVERROR_STREAM_NOT_FOUND)
-        {
-            auto s = std::make_unique<sound_frame_t>();
+    virtual std::unique_ptr<sound_frame_t> next_sound() {
+        if (ixa != AVERROR_STREAM_NOT_FOUND) {
             return sound_->extract(sound_ix++);
         }
         return nullptr;
     }
 };
 
-std::unique_ptr<input_reader> make_ffmpeg_reader(const std::string &movie_path, double from, double to)
-{
-    try
-    {
+std::unique_ptr<input_reader> make_ffmpeg_reader(const std::string &movie_path, double from, double to) {
+    try {
         return std::make_unique<ffmpeg_reader>(movie_path, from, to - from);
-    }
-    catch (const char *e)
-    {
+    } catch (const char *e) {
         std::clog << "**** ERROR : " << e << "\n";
         return nullptr;
     }

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -2,34 +2,31 @@
 
 #include <iostream>
 
-extern "C"{
-    #include <libavcodec/avcodec.h>
-    #include <libavformat/avformat.h>
-    #include <libavutil/avutil.h>
-    #include <libavutil/time.h>
-    #include <libavutil/opt.h>
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libavutil/time.h>
+#include <libavutil/opt.h>
 }
 
 extern bool sDebug;
 
-class ffmpeg_writer : public output_writer
-{
-    size_t W_;  //  Should be in output_writer
-    size_t H_;
-
+class ffmpeg_writer : public output_writer {
+size_t W_; // Should be in output_writer
+size_t H_;
 
 /* check that a given sample format is supported by the encoder */
-static int check_sample_fmt(const AVCodec *codec, enum AVSampleFormat sample_fmt)
-{
-    const enum AVSampleFormat *p = codec->sample_fmts;
-    while (*p != AV_SAMPLE_FMT_NONE) {
-        if (sDebug)
-            std::clog << "[ " << av_get_sample_fmt_name(*p) << "] ";
-        if (*p == sample_fmt)
-            return 1;
-        p++;
-    }
-    return 0;
+static int check_sample_fmt(const AVCodec *codec, enum AVSampleFormat sample_fmt) {
+const enum AVSampleFormat *p = codec->sample_fmts;
+while (*p != AV_SAMPLE_FMT_NONE) {
+if (sDebug)
+std::clog << "[ " << av_get_sample_fmt_name(*p) << "] ";
+if (*p == sample_fmt)
+return 1;
+p++;
+}
+return 0;
 }
 
 AVFrame *videoFrame = nullptr;
@@ -38,509 +35,333 @@ AVCodecContext* video_context = nullptr;
 AVCodecContext* audio_context = nullptr;
 int frameCounter = 0;
 AVFormatContext* ofctx = nullptr;
-AVOutputFormat* oformat = nullptr;
+const AVOutputFormat* oformat = nullptr;
 
-    //  Small state for audio encoding (22100 in 370 u8 sample to 44200 in 1024 flt samples)
+// Small state for audio encoding (22100 in 370 u8 sample to 44200 in 1024 flt samples)
 float audio_44[735];
 size_t audio_pos = 0;
 int audio_frame_counter = 0;
 
+void pushFrame(const image &img, const sound_frame_t &snd) {
+int err;
+if (!videoFrame) {
+videoFrame = av_frame_alloc();
+if (!videoFrame) {
+throw "Failed to allocate video frame";
+}
+videoFrame->format = AV_PIX_FMT_YUV420P;
+videoFrame->width = video_context->width;
+videoFrame->height = video_context->height;
+if ((err = av_frame_get_buffer(videoFrame, 32)) < 0) {
+std::cout << "Failed to allocate picture buffer: " << err << std::endl;
+return;
+}
+av_frame_make_writable(videoFrame);
 
-void pushFrame( const image &img, const sound_frame_t &snd )
-{
-    int err;
-    if (!videoFrame)
-    {
-        videoFrame = av_frame_alloc();
-        videoFrame->format = AV_PIX_FMT_YUV420P;
-        videoFrame->width = video_context->width;
-        videoFrame->height = video_context->height;
-        if ((err = av_frame_get_buffer(videoFrame, 32)) < 0)
-        {
-            std::cout << "Failed to allocate picture" << err << std::endl;
-            return;
-        }
-        av_frame_make_writable(videoFrame);
-
-        // std::cout << videoFrame->linesize[0] << " ";
-        // std::cout << videoFrame->linesize[1] << " ";
-        // std::cout << videoFrame->linesize[2] << "\n";
-
-        // for (int i=0;i!=342;i++)
-        //     memset( videoFrame->data[0]+512*i, i, 512 );
-
-        memset( videoFrame->data[1], 128, H_/2*videoFrame->linesize[1] );
-        memset( videoFrame->data[2], 128, H_/2*videoFrame->linesize[2] );
-    }
-
-        uint8_t *p = videoFrame->data[0];
-        for (size_t y=0;y!=H_;y++)
-            for (size_t x=0;x!=W_;x++)
-            {
-                auto v = img.at(x,y);
-                if (v<=0.5) *p++ = 0;
-                else *p++ = 255;
-            }
-
-    videoFrame->pts = 1500 * frameCounter;  //  #### WHY??? (voice of Bronsky Beat)
-
-    // std::clog << "TB=" << av_q2d(cctx->time_base) << "\n";
-
-// exit(0);
-
-    // std::cout << videoFrame->pts << " " << cctx->time_base.num << " " << 
-    //     cctx->time_base.den << " " << frameCounter << std::endl;
-    if ((err = avcodec_send_frame(video_context, videoFrame)) < 0) {
-        std::cout << "Failed to send frame" << err << std::endl;
-        return;
-    }
-    // AV_TIME_BASE;
-    AVPacket pkt;
-    av_init_packet(&pkt);
-    pkt.data = NULL;
-    pkt.size = 0;
-    pkt.flags |= AV_PKT_FLAG_KEY;
-    if (avcodec_receive_packet(video_context, &pkt) == 0) {
-        // static int counter = 0;
-        // if (counter == 0) {
-        //     FILE* fp = fopen("dump_first_frame1.dat", "wb");
-        //     fwrite(pkt.data, pkt.size, 1, fp);
-        //     fclose(fp);
-        //     counter++;
-        // }
-        // std::cout << "pkt key: " << (pkt.flags & AV_PKT_FLAG_KEY) << " " << 
-        //     pkt.size << "\n";
-        // uint8_t* size = ((uint8_t*)pkt.data);
-        // std::cout << "first: " << (int)size[0] << " " << (int)size[1] << 
-        //     " " << (int)size[2] << " " << (int)size[3] << " " << (int)size[4] << 
-        //     " " << (int)size[5] << " " << (int)size[6] << " " << (int)size[7] << 
-        //     std::endl;
-        av_interleaved_write_frame(ofctx, &pkt);
-        av_packet_unref(&pkt);
-    }
-
-    float *audio_p = (float *)audio_frame->data[0];
-
-//  AUDIO
-
-        //  We convert to 44KHz
-    for (int i=0;i!=735;i++)
-        audio_44[i] = (*(snd.begin()+(int)(i/735.0*370))-128.0)/128;
-
-
-        //  How many samples left to send?
-    if (audio_pos+735>=1024)
-    {
-            //  Fill the audio out buffer
-        memcpy( audio_p+audio_pos, audio_44, (1024-audio_pos)*sizeof(float) );
-
-            //  Send to encoder
-        audio_frame->pts = audio_frame_counter*1024;
-        audio_frame_counter++;
-
-        /* send the frame for encoding */
-        err = avcodec_send_frame( audio_context, audio_frame);
-        if (err < 0)
-            throw "Error sending the frame to the encoder";
-
-        err = avcodec_receive_packet( audio_context, &pkt);
-        if (err == AVERROR(EAGAIN) || err == AVERROR_EOF)
-            return;
-        else if (err < 0)
-            throw "Error encoding audio frame";
-
-        pkt.stream_index = 1;
-        av_interleaved_write_frame( ofctx, &pkt );
-
-        av_packet_unref(&pkt);
-
-            //  Fill the audio start
-        memcpy( audio_p, audio_44+1024-audio_pos, (735-1024+audio_pos)*sizeof(float) );
-        audio_pos = 735-1024+audio_pos;
-    }
-    else
-    {
-        memcpy( audio_p+audio_pos, audio_44, 735*sizeof(float) );
-        audio_pos += 735;
-    }
-
-    frameCounter++;
+memset(videoFrame->data[1], 128, H_/2 * videoFrame->linesize[1]);
+memset(videoFrame->data[2], 128, H_/2 * videoFrame->linesize[2]);
 }
 
-static AVCodec *dump_codecs()
-{
-    void *i = 0;
-    const AVCodec *p;
-  
-    while ((p = av_codec_iterate(&i)))
-    {
-        if (p->encode2 /* || p->send_frame */)
-            std::clog << p->name << " ";
-    }
+uint8_t *p = videoFrame->data[0];
+for (size_t y = 0; y != H_; y++) {
+for (size_t x = 0; x != W_; x++) {
+auto v = img.at(x, y);
+*p++ = v <= 0.5 ? 0 : 255;
+}
+}
 
-    std::clog << "\n";
+videoFrame->pts = 1500 * frameCounter;
 
-    return NULL;
- }
+if ((err = avcodec_send_frame(video_context, videoFrame)) < 0) {
+std::cout << "Failed to send frame: " << err << std::endl;
+return;
+}
 
-public:
-    ffmpeg_writer( const std::string filename, size_t W, size_t H )
-    {
-        W_ = W;
-        H_ = H;
-    av_register_all();
+AVPacket pkt;
+av_init_packet(&pkt);
+pkt.data = NULL;
+pkt.size = 0;
+pkt.flags |= AV_PKT_FLAG_KEY;
+if (avcodec_receive_packet(video_context, &pkt) == 0) {
+av_interleaved_write_frame(ofctx, &pkt);
+av_packet_unref(&pkt);
+}
 
-    oformat = av_guess_format(nullptr, filename.c_str(), nullptr);
-    if (!oformat)
-    {
-        throw "Can't create output format";
-    }
-
-    int err = avformat_alloc_output_context2(&ofctx, oformat, nullptr, filename.c_str());
-    if (err)
-    {
-        throw "can't create output context";
-    }
-
-    AVCodec* video_codec = nullptr;
-    video_codec = avcodec_find_encoder(oformat->video_codec);
-    if (!video_codec)
-    {
-        throw "Can't create video codec";
-    }
-
-    AVStream* stream = avformat_new_stream(ofctx, video_codec);
-    if (!stream)
-    {
-        std::cout << "can't find format" << std::endl;
-    }
-
-    video_context = avcodec_alloc_context3(video_codec);
-
-    if (!video_context)
-    {
-        throw "Can't create video codec context";
-    }
-
-    stream->codecpar->codec_id = oformat->video_codec;
-    stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
-    stream->codecpar->width = W_;
-    stream->codecpar->height = H_;
-    stream->codecpar->format = AV_PIX_FMT_YUV420P;
-    stream->codecpar->bit_rate = 60 * 6000 * 8;
-    avcodec_parameters_to_context( video_context, stream->codecpar );
-    video_context->time_base = (AVRational){ 1, 30 };
-    video_context->max_b_frames = 2;
-    video_context->gop_size = 12;
-    video_context->framerate = (AVRational){ 60, 1 };
-
-    //must remove the following
-    // cctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-
-    if (stream->codecpar->codec_id == AV_CODEC_ID_H264)
-    {
-        av_opt_set(video_context, "preset", "ultrafast", 0);
-//  The next line has no effect on the compression (???)
-//         av_opt_set(video_context, "preset", "veryslow", 0);
-// std::cout << "CODEC PRESET H264 SLOW\n";
-    }
-    else if (stream->codecpar->codec_id == AV_CODEC_ID_H265)
-    {
-        av_opt_set(video_context, "preset", "ultrafast", 0);
-//  The next line has no effect on the compression (???)
-//         av_opt_set(video_context, "preset", "slow", 0);
-// std::cout << "CODEC PRESET H265 SLOW\n";
-    }
-
-    avcodec_parameters_from_context( stream->codecpar, video_context );
-
-    if ((err = avcodec_open2( video_context, video_codec, NULL )) < 0)
-    {
-        throw "Failed to open codec";
-    }
+float *audio_p = (float *)audio_frame->data[0];
 
 // AUDIO
-    /* find the MP2 encoder */
-    // auto audio_codec = avcodec_find_encoder(AV_CODEC_ID_PCM_U8);
-    // if (!audio_codec)
-    //     throw "Audio codec not found";
-
-    auto audio_codec = avcodec_find_encoder(oformat->audio_codec);
-    if (!audio_codec)
-        throw "Audio codec not found";
-
-    audio_context = avcodec_alloc_context3(audio_codec);
-    if (!audio_context)
-        throw "Could not allocate audio codec context";
-
-    /* put sample parameters */
-    // audio_context->bit_rate = 22200;
-
-    /* check that the encoder supports u8 pcm input */
-    audio_context->sample_fmt = AV_SAMPLE_FMT_FLTP;
-    if (!check_sample_fmt(audio_codec, audio_context->sample_fmt))
-        throw "Encoder does not support FLT planar samples";
-                // av_get_sample_fmt_name(c-planarsample_fmt));
-
-
-
-//    audio_context->bit_rate = 22200*8;
-    audio_context->sample_rate = 44100;
-    audio_context->channel_layout = AV_CH_LAYOUT_MONO;
-    audio_context->channels       = 1;
-
-    /* open it */
-    if (avcodec_open2( audio_context, audio_codec, NULL ) < 0)
-        throw "Could not open audio codec";
-
-    //  argh, avcodec_open2 set the frame_size to 1024!
-    // audio_context->frame_size     = 735;
-
-
-    AVStream* audio_stream = avformat_new_stream( ofctx, audio_codec );
-    if (!audio_stream)
-    {
-        throw "Cannot create audio stream";
-    }
-
-
-    audio_stream->id = 1;   //  ???
-
-    audio_stream->time_base = (AVRational){ 1, 1 };
-    avcodec_parameters_from_context( audio_stream->codecpar, audio_context );
-
-
-
-
-
-
-
-
-    audio_frame = av_frame_alloc();
-    if (!audio_frame)
-       throw "Error allocating an audio frame";
-
-    audio_frame->format = audio_context->sample_fmt;
-    audio_frame->channel_layout = audio_context->channel_layout;
-    audio_frame->sample_rate = audio_context->sample_rate;
-    audio_frame->nb_samples = 1024;      //  44100/60
-    err = av_frame_get_buffer(audio_frame, 0);
-    if (err < 0)
-    {
-        throw "Error allocating an audio buffer";
-    }
-
-    if (sDebug)
-    {
-        std::clog << "Line size = " << audio_frame->linesize[0] << "\n";
-        std::clog << "Frame size = " << audio_context->frame_size << "\n";
-    } 
-
-// exit(0);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    if (!(oformat->flags & AVFMT_NOFILE))
-    {
-        if ((err = avio_open(&ofctx->pb, filename.c_str(), AVIO_FLAG_WRITE)) < 0)
-        {
-            throw "Failed to open file";
-        }
-    }
-
-    if ((err = avformat_write_header(ofctx, NULL)) < 0)
-    {
-        char buffer[1025];
-        av_strerror( err, buffer, 1024 );
-        std::clog << err << ":" << buffer << "\n";
-
-        throw "Failed to write header";
-    }
-
-    av_dump_format(ofctx, 0, filename.c_str(), 1);
-
-    }
-
-    ~ffmpeg_writer()
-    {
-
-    if (sDebug)
-        std::clog << "~ffmpeg_writer()\n";
-
-    //DELAYED FRAMES
-    AVPacket pkt;
-    av_init_packet(&pkt);
-    pkt.data = NULL;
-    pkt.size = 0;
-
-    for (;;) {
-        avcodec_send_frame(video_context, NULL);
-        if (avcodec_receive_packet(video_context, &pkt) == 0) {
-            av_interleaved_write_frame(ofctx, &pkt);
-            av_packet_unref(&pkt);
-        }
-        else {
-            break;
-        }
-    }
-
-/// Test to flush the 2 last audio frames, does not work
-/// "Application provided invalid, non monotonically increasing dts to muxer in stream 0: 354000 >= 175104"
-    // for (;;) {
-    //     avcodec_send_frame(audio_context, NULL);
-    //     if (avcodec_receive_packet(audio_context, &pkt) == 0) {
-    //         av_interleaved_write_frame(ofctx, &pkt);
-    //         av_packet_unref(&pkt);
-    //     }
-    //     else {
-    //         break;
-    //     }
-    // }
-
-
-
-
-
-
-    av_write_trailer(ofctx);
-    if (!(oformat->flags & AVFMT_NOFILE))
-    {
-        int err = avio_close(ofctx->pb);
-        if (err < 0) {
-            std::cout << "Failed to close file" << err << std::endl;
-        }
-    }
-
-    if (videoFrame)
-    {
-        av_frame_free(&videoFrame);
-    }
-    if (audio_frame)
-    {
-        av_frame_free(&audio_frame);
-    }
-    if (video_context)
-    {
-        avcodec_free_context(&video_context);
-    }
-    if (audio_context)
-    {
-        avcodec_free_context(&audio_context);
-    }
-    if (ofctx)
-    {
-        avformat_free_context(ofctx);
-    }
-
-    if (sDebug)
-        std::clog << "#### End of video stream\n";
+// We convert to 44KHz
+for (int i = 0; i != 735; i++) {
+audio_44[i] = (*(snd.begin() + (int)(i / 735.0 * 370)) - 128.0) / 128;
 }
-    virtual void write_frame( const image& img, const sound_frame_t &snd )
-    {
-        pushFrame( img, snd );
-    }
-};
 
+// How many samples left to send?
+if (audio_pos + 735 >= 1024) {
+memcpy(audio_p + audio_pos, audio_44, (1024 - audio_pos) * sizeof(float));
 
-class gif_writer : public output_writer
-{
-    size_t count_ = 0;
-    size_t num_ = 0;
-    std::string filename_;
+audio_frame->pts = audio_frame_counter * 1024;
+audio_frame_counter++;
+
+err = avcodec_send_frame(audio_context, audio_frame);
+if (err < 0)
+throw "Error sending the frame to the encoder";
+
+err = avcodec_receive_packet(audio_context, &pkt);
+if (err == AVERROR(EAGAIN) || err == AVERROR_EOF)
+return;
+else if (err < 0)
+throw "Error encoding audio frame";
+
+pkt.stream_index = 1; // Corrected this line
+
+av_interleaved_write_frame(ofctx, &pkt);
+av_packet_unref(&pkt);
+
+memcpy(audio_p, audio_44 + 1024 - audio_pos, (735 - 1024 + audio_pos) * sizeof(float));
+audio_pos = 735 - 1024 + audio_pos;
+} else {
+memcpy(audio_p + audio_pos, audio_44, 735 * sizeof(float));
+audio_pos += 735;
+}
+
+frameCounter++;
+}
+
+static void dump_codecs() {
+void *i = 0;
+const AVCodec *p;
+
+while ((p = av_codec_iterate(&i))) {
+std::clog << p->name << " ";
+}
+
+std::clog << "\n";
+}
 
 public:
-    gif_writer( const std::string filename ) : filename_{ filename } {}
+ffmpeg_writer(const std::string filename, size_t W, size_t H) {
+W_ = W;
+H_ = H;
 
-    virtual void write_frame( const image& img, [[maybe_unused]] const sound_frame_t &snd )
-    {
-        if ((count_%3)==0)
-        {
-            char buffer[1024];
-            sprintf( buffer, "/tmp/gif-%06lu.pgm", num_ );
-            write_image( buffer, img );
-            num_++;
-        }
-        count_++;
-    }
+oformat = av_guess_format(nullptr, filename.c_str(), nullptr);
+if (!oformat) {
+throw "Can't create output format";
+}
 
-    ~gif_writer()
-    {
-        char buffer[1024];
-        sprintf( buffer, "convert -delay 5 -loop 0 /tmp/gif-*.pgm '%s'", filename_.c_str() );
-        std::clog << "GENERATING GIF FILE\n";
-        int res = system( buffer );
-        if (res!=0)
-        {
-            std::cerr << "**** FAILED TO GENERATE GIF FILE (retcode=" << res << ")\n";
-        }
-        std::clog << "DONE\n";
-        //  #### This is missing the file '0'
-        delete_files_of_pattern( "/tmp/gif-%06d.pgm" );
-    }
+int err = avformat_alloc_output_context2(&ofctx, oformat, nullptr, filename.c_str());
+if (err < 0) {
+throw "can't create output context";
+}
+
+const AVCodec* video_codec = nullptr;
+video_codec = avcodec_find_encoder(oformat->video_codec);
+if (!video_codec) {
+throw "Can't create video codec";
+}
+
+AVStream* stream = avformat_new_stream(ofctx, video_codec);
+if (!stream) {
+std::cout << "can't find format" << std::endl;
+}
+
+video_context = avcodec_alloc_context3(video_codec);
+
+if (!video_context) {
+throw "Can't create video codec context";
+}
+
+stream->codecpar->codec_id = oformat->video_codec;
+stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+stream->codecpar->width = W_;
+stream->codecpar->height = H_;
+stream->codecpar->format = AV_PIX_FMT_YUV420P;
+stream->codecpar->bit_rate = 60 * 6000 * 8;
+
+int ret = avcodec_parameters_to_context(video_context, stream->codecpar);
+if (ret < 0) {
+throw "Failed to copy codec parameters to context";
+}
+
+video_context->time_base = (AVRational){ 1, 30 };
+video_context->max_b_frames = 2;
+video_context->gop_size = 12;
+video_context->framerate = (AVRational){ 60, 1 };
+
+if (stream->codecpar->codec_id == AV_CODEC_ID_H264) {
+av_opt_set(video_context, "preset", "ultrafast", 0);
+} else if (stream->codecpar->codec_id == AV_CODEC_ID_H265) {
+av_opt_set(video_context, "preset", "ultrafast", 0);
+}
+
+avcodec_parameters_from_context(stream->codecpar, video_context);
+
+if ((err = avcodec_open2(video_context, video_codec, NULL)) < 0) {
+throw "Failed to open codec";
+}
+
+// AUDIO
+auto audio_codec = avcodec_find_encoder(oformat->audio_codec);
+if (!audio_codec)
+throw "Audio codec not found";
+
+audio_context = avcodec_alloc_context3(audio_codec);
+if (!audio_context)
+throw "Could not allocate audio codec context";
+
+audio_context->sample_fmt = AV_SAMPLE_FMT_FLTP;
+if (!check_sample_fmt(audio_codec, audio_context->sample_fmt))
+throw "Encoder does not support FLT planar samples";
+
+audio_context->sample_rate = 44100;
+audio_context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_MONO;
+audio_context->ch_layout.nb_channels = 1;
+
+ret = avcodec_open2(audio_context, audio_codec, NULL);
+if (ret < 0) {
+throw "Could not open audio codec";
+}
+
+AVStream* audio_stream = avformat_new_stream(ofctx, audio_codec);
+if (!audio_stream) {
+throw "Cannot create audio stream";
+}
+
+audio_stream->id = 1;
+
+audio_stream->time_base = (AVRational){ 1, 44100 };
+avcodec_parameters_from_context(audio_stream->codecpar, audio_context);
+
+audio_frame = av_frame_alloc();
+if (!audio_frame)
+throw "Error allocating an audio frame";
+
+audio_frame->format = audio_context->sample_fmt;
+audio_frame->ch_layout = audio_context->ch_layout;
+audio_frame->sample_rate = audio_context->sample_rate;
+audio_frame->nb_samples = 1024; // 44100/60
+err = av_frame_get_buffer(audio_frame, 0);
+if (err < 0) {
+throw "Error allocating an audio buffer";
+}
+
+if (sDebug) {
+std::clog << "Line size = " << audio_frame->linesize[0] << "\n";
+std::clog << "Frame size = " << audio_context->frame_size << "\n";
+}
+
+if (!(oformat->flags & AVFMT_NOFILE)) {
+if ((err = avio_open(&ofctx->pb, filename.c_str(), AVIO_FLAG_WRITE)) < 0) {
+throw "Failed to open file";
+}
+}
+
+if ((err = avformat_write_header(ofctx, NULL)) < 0) {
+char buffer[1025];
+av_strerror(err, buffer, 1024);
+std::clog << err << ": " << buffer << "\n";
+throw "Failed to write header";
+}
+
+av_dump_format(ofctx, 0, filename.c_str(), 1);
+}
+
+~ffmpeg_writer() {
+if (sDebug)
+std::clog << "~ffmpeg_writer()\n";
+
+// DELAYED FRAMES
+AVPacket pkt;
+av_init_packet(&pkt);
+pkt.data = NULL;
+pkt.size = 0;
+
+for (;;) {
+avcodec_send_frame(video_context, NULL);
+if (avcodec_receive_packet(video_context, &pkt) == 0) {
+av_interleaved_write_frame(ofctx, &pkt);
+av_packet_unref(&pkt);
+} else {
+break;
+}
+}
+
+av_write_trailer(ofctx);
+if (!(oformat->flags & AVFMT_NOFILE)) {
+int err = avio_close(ofctx->pb);
+if (err < 0) {
+std::cout << "Failed to close file: " << err << std::endl;
+}
+}
+
+if (videoFrame) {
+av_frame_free(&videoFrame);
+}
+if (audio_frame) {
+av_frame_free(&audio_frame);
+}
+if (video_context) {
+avcodec_free_context(&video_context);
+}
+if (audio_context) {
+avcodec_free_context(&audio_context);
+}
+if (ofctx) {
+avformat_free_context(ofctx);
+}
+
+if (sDebug)
+std::clog << "#### End of video stream\n";
+}
+
+virtual void write_frame(const image& img, const sound_frame_t &snd) {
+pushFrame(img, snd);
+}
 };
 
-std::unique_ptr<output_writer> make_ffmpeg_writer( const std::string &movie_path, size_t w, size_t h )
-{
-    return std::make_unique<ffmpeg_writer>( movie_path, w, h );
-}
+class gif_writer : public output_writer {
+size_t count_ = 0;
+size_t num_ = 0;
+std::string filename_;
 
-std::unique_ptr<output_writer> make_gif_writer( const std::string &movie_path, [[maybe_unused]] size_t w, [[maybe_unused]] size_t h )
-{
-    return std::make_unique<gif_writer>( movie_path );
-}
-
-class null_writer : public output_writer
-{
 public:
-    virtual void write_frame( [[maybe_unused]] const image& img, [[maybe_unused]] const sound_frame_t &snd )
-    {
-    }
+gif_writer(const std::string filename) : filename_{ filename } {}
+
+virtual void write_frame(const image& img, [[maybe_unused]] const sound_frame_t &snd) {
+if ((count_ % 3) == 0) {
+char buffer[1024];
+sprintf(buffer, "/tmp/gif-%06lu.pgm", num_);
+write_image(buffer, img);
+num_++;
+}
+count_++;
+}
+
+~gif_writer() {
+char buffer[1024];
+sprintf(buffer, "convert -delay 5 -loop 0 /tmp/gif-*.pgm '%s'", filename_.c_str());
+std::clog << "GENERATING GIF FILE\n";
+int res = system(buffer);
+if (res != 0) {
+std::cerr << "**** FAILED TO GENERATE GIF FILE (retcode=" << res << ")\n";
+}
+std::clog << "DONE\n";
+delete_files_of_pattern("/tmp/gif-%06d.pgm");
+}
 };
 
-std::unique_ptr<output_writer> make_null_writer()
-{
-    return std::make_unique<null_writer>();
+std::unique_ptr<output_writer> make_ffmpeg_writer(const std::string &movie_path, size_t w, size_t h) {
+return std::make_unique<ffmpeg_writer>(movie_path, w, h);
+}
+
+std::unique_ptr<output_writer> make_gif_writer(const std::string &movie_path, [[maybe_unused]] size_t w, [[maybe_unused]] size_t h) {
+return std::make_unique<gif_writer>(movie_path);
+}
+
+class null_writer : public output_writer {
+public:
+virtual void write_frame([[maybe_unused]] const image& img, [[maybe_unused]] const sound_frame_t &snd) {}
+};
+
+std::unique_ptr<output_writer> make_null_writer() {
+return std::make_unique<null_writer>();
 }

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -3,365 +3,365 @@
 #include <iostream>
 
 extern "C" {
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-#include <libavutil/avutil.h>
-#include <libavutil/time.h>
-#include <libavutil/opt.h>
+    #include <libavcodec/avcodec.h>
+    #include <libavformat/avformat.h>
+    #include <libavutil/avutil.h>
+    #include <libavutil/time.h>
+    #include <libavutil/opt.h>
 }
 
 extern bool sDebug;
 
 class ffmpeg_writer : public output_writer {
-size_t W_; // Should be in output_writer
-size_t H_;
+    size_t W_; // Should be in output_writer
+    size_t H_;
 
-/* check that a given sample format is supported by the encoder */
-static int check_sample_fmt(const AVCodec *codec, enum AVSampleFormat sample_fmt) {
-const enum AVSampleFormat *p = codec->sample_fmts;
-while (*p != AV_SAMPLE_FMT_NONE) {
-if (sDebug)
-std::clog << "[ " << av_get_sample_fmt_name(*p) << "] ";
-if (*p == sample_fmt)
-return 1;
-p++;
-}
-return 0;
-}
+    /* check that a given sample format is supported by the encoder */
+    static int check_sample_fmt(const AVCodec *codec, enum AVSampleFormat sample_fmt) {
+        const enum AVSampleFormat *p = codec->sample_fmts;
+        while (*p != AV_SAMPLE_FMT_NONE) {
+            if (sDebug)
+                std::clog << "[ " << av_get_sample_fmt_name(*p) << "] ";
+            if (*p == sample_fmt)
+                return 1;
+            p++;
+        }
+        return 0;
+    }
 
-AVFrame *videoFrame = nullptr;
-AVFrame *audio_frame = nullptr;
-AVCodecContext* video_context = nullptr;
-AVCodecContext* audio_context = nullptr;
-int frameCounter = 0;
-AVFormatContext* ofctx = nullptr;
-const AVOutputFormat* oformat = nullptr;
+    AVFrame *videoFrame = nullptr;
+    AVFrame *audio_frame = nullptr;
+    AVCodecContext* video_context = nullptr;
+    AVCodecContext* audio_context = nullptr;
+    int frameCounter = 0;
+    AVFormatContext* ofctx = nullptr;
+    const AVOutputFormat* oformat = nullptr;
 
-// Small state for audio encoding (22100 in 370 u8 sample to 44200 in 1024 flt samples)
-float audio_44[735];
-size_t audio_pos = 0;
-int audio_frame_counter = 0;
+    // Small state for audio encoding (22100 in 370 u8 sample to 44200 in 1024 flt samples)
+    float audio_44[735];
+    size_t audio_pos = 0;
+    int audio_frame_counter = 0;
 
-void pushFrame(const image &img, const sound_frame_t &snd) {
-int err;
-if (!videoFrame) {
-videoFrame = av_frame_alloc();
-if (!videoFrame) {
-throw "Failed to allocate video frame";
-}
-videoFrame->format = AV_PIX_FMT_YUV420P;
-videoFrame->width = video_context->width;
-videoFrame->height = video_context->height;
-if ((err = av_frame_get_buffer(videoFrame, 32)) < 0) {
-std::cout << "Failed to allocate picture buffer: " << err << std::endl;
-return;
-}
-av_frame_make_writable(videoFrame);
+    void pushFrame(const image &img, const sound_frame_t &snd) {
+        int err;
+        if (!videoFrame) {
+            videoFrame = av_frame_alloc();
+            if (!videoFrame) {
+                throw "Failed to allocate video frame";
+            }
+            videoFrame->format = AV_PIX_FMT_YUV420P;
+            videoFrame->width = video_context->width;
+            videoFrame->height = video_context->height;
+            if ((err = av_frame_get_buffer(videoFrame, 32)) < 0) {
+                std::cout << "Failed to allocate picture buffer: " << err << std::endl;
+                return;
+            }
+            av_frame_make_writable(videoFrame);
 
-memset(videoFrame->data[1], 128, H_/2 * videoFrame->linesize[1]);
-memset(videoFrame->data[2], 128, H_/2 * videoFrame->linesize[2]);
-}
+            memset(videoFrame->data[1], 128, H_/2 * videoFrame->linesize[1]);
+            memset(videoFrame->data[2], 128, H_/2 * videoFrame->linesize[2]);
+        }
 
-uint8_t *p = videoFrame->data[0];
-for (size_t y = 0; y != H_; y++) {
-for (size_t x = 0; x != W_; x++) {
-auto v = img.at(x, y);
-*p++ = v <= 0.5 ? 0 : 255;
-}
-}
+        uint8_t *p = videoFrame->data[0];
+        for (size_t y = 0; y != H_; y++) {
+            for (size_t x = 0; x != W_; x++) {
+                auto v = img.at(x, y);
+                *p++ = v <= 0.5 ? 0 : 255;
+            }
+        }
 
-videoFrame->pts = 1500 * frameCounter;
+        videoFrame->pts = 1500 * frameCounter;
 
-if ((err = avcodec_send_frame(video_context, videoFrame)) < 0) {
-std::cout << "Failed to send frame: " << err << std::endl;
-return;
-}
+        if ((err = avcodec_send_frame(video_context, videoFrame)) < 0) {
+            std::cout << "Failed to send frame: " << err << std::endl;
+            return;
+        }
 
-AVPacket pkt;
-av_init_packet(&pkt);
-pkt.data = NULL;
-pkt.size = 0;
-pkt.flags |= AV_PKT_FLAG_KEY;
-if (avcodec_receive_packet(video_context, &pkt) == 0) {
-av_interleaved_write_frame(ofctx, &pkt);
-av_packet_unref(&pkt);
-}
+        AVPacket pkt;
+        av_init_packet(&pkt);
+        pkt.data = NULL;
+        pkt.size = 0;
+        pkt.flags |= AV_PKT_FLAG_KEY;
+        if (avcodec_receive_packet(video_context, &pkt) == 0) {
+            av_interleaved_write_frame(ofctx, &pkt);
+            av_packet_unref(&pkt);
+        }
 
-float *audio_p = (float *)audio_frame->data[0];
+        float *audio_p = (float *)audio_frame->data[0];
 
-// AUDIO
-// We convert to 44KHz
-for (int i = 0; i != 735; i++) {
-audio_44[i] = (*(snd.begin() + (int)(i / 735.0 * 370)) - 128.0) / 128;
-}
+        // AUDIO
+        // We convert to 44KHz
+        for (int i = 0; i != 735; i++) {
+            audio_44[i] = (*(snd.begin() + (int)(i / 735.0 * 370)) - 128.0) / 128;
+        }
 
-// How many samples left to send?
-if (audio_pos + 735 >= 1024) {
-memcpy(audio_p + audio_pos, audio_44, (1024 - audio_pos) * sizeof(float));
+        // How many samples left to send?
+        if (audio_pos + 735 >= 1024) {
+            memcpy(audio_p + audio_pos, audio_44, (1024 - audio_pos) * sizeof(float));
 
-audio_frame->pts = audio_frame_counter * 1024;
-audio_frame_counter++;
+            audio_frame->pts = audio_frame_counter * 1024;
+            audio_frame_counter++;
 
-err = avcodec_send_frame(audio_context, audio_frame);
-if (err < 0)
-throw "Error sending the frame to the encoder";
+            err = avcodec_send_frame(audio_context, audio_frame);
+            if (err < 0)
+                throw "Error sending the frame to the encoder";
 
-err = avcodec_receive_packet(audio_context, &pkt);
-if (err == AVERROR(EAGAIN) || err == AVERROR_EOF)
-return;
-else if (err < 0)
-throw "Error encoding audio frame";
+            err = avcodec_receive_packet(audio_context, &pkt);
+            if (err == AVERROR(EAGAIN) || err == AVERROR_EOF)
+                return;
+            else if (err < 0)
+                throw "Error encoding audio frame";
 
-pkt.stream_index = 1; // Corrected this line
+            pkt.stream_index = 1; // Corrected this line
 
-av_interleaved_write_frame(ofctx, &pkt);
-av_packet_unref(&pkt);
+            av_interleaved_write_frame(ofctx, &pkt);
+            av_packet_unref(&pkt);
 
-memcpy(audio_p, audio_44 + 1024 - audio_pos, (735 - 1024 + audio_pos) * sizeof(float));
-audio_pos = 735 - 1024 + audio_pos;
-} else {
-memcpy(audio_p + audio_pos, audio_44, 735 * sizeof(float));
-audio_pos += 735;
-}
+            memcpy(audio_p, audio_44 + 1024 - audio_pos, (735 - 1024 + audio_pos) * sizeof(float));
+            audio_pos = 735 - 1024 + audio_pos;
+        } else {
+            memcpy(audio_p + audio_pos, audio_44, 735 * sizeof(float));
+            audio_pos += 735;
+        }
 
-frameCounter++;
-}
+        frameCounter++;
+    }
 
-static void dump_codecs() {
-void *i = 0;
-const AVCodec *p;
+    static void dump_codecs() {
+        void *i = 0;
+        const AVCodec *p;
 
-while ((p = av_codec_iterate(&i))) {
-std::clog << p->name << " ";
-}
+        while ((p = av_codec_iterate(&i))) {
+            std::clog << p->name << " ";
+        }
 
-std::clog << "\n";
-}
+        std::clog << "\n";
+    }
 
 public:
-ffmpeg_writer(const std::string filename, size_t W, size_t H) {
-W_ = W;
-H_ = H;
+    ffmpeg_writer(const std::string filename, size_t W, size_t H) {
+        W_ = W;
+        H_ = H;
 
-oformat = av_guess_format(nullptr, filename.c_str(), nullptr);
-if (!oformat) {
-throw "Can't create output format";
-}
+        oformat = av_guess_format(nullptr, filename.c_str(), nullptr);
+        if (!oformat) {
+            throw "Can't create output format";
+        }
 
-int err = avformat_alloc_output_context2(&ofctx, oformat, nullptr, filename.c_str());
-if (err < 0) {
-throw "can't create output context";
-}
+        int err = avformat_alloc_output_context2(&ofctx, oformat, nullptr, filename.c_str());
+        if (err < 0) {
+            throw "can't create output context";
+        }
 
-const AVCodec* video_codec = nullptr;
-video_codec = avcodec_find_encoder(oformat->video_codec);
-if (!video_codec) {
-throw "Can't create video codec";
-}
+        const AVCodec* video_codec = nullptr;
+        video_codec = avcodec_find_encoder(oformat->video_codec);
+        if (!video_codec) {
+            throw "Can't create video codec";
+        }
 
-AVStream* stream = avformat_new_stream(ofctx, video_codec);
-if (!stream) {
-std::cout << "can't find format" << std::endl;
-}
+        AVStream* stream = avformat_new_stream(ofctx, video_codec);
+        if (!stream) {
+            std::cout << "can't find format" << std::endl;
+        }
 
-video_context = avcodec_alloc_context3(video_codec);
+        video_context = avcodec_alloc_context3(video_codec);
 
-if (!video_context) {
-throw "Can't create video codec context";
-}
+        if (!video_context) {
+            throw "Can't create video codec context";
+        }
 
-stream->codecpar->codec_id = oformat->video_codec;
-stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
-stream->codecpar->width = W_;
-stream->codecpar->height = H_;
-stream->codecpar->format = AV_PIX_FMT_YUV420P;
-stream->codecpar->bit_rate = 60 * 6000 * 8;
+        stream->codecpar->codec_id = oformat->video_codec;
+        stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+        stream->codecpar->width = W_;
+        stream->codecpar->height = H_;
+        stream->codecpar->format = AV_PIX_FMT_YUV420P;
+        stream->codecpar->bit_rate = 60 * 6000 * 8;
 
-int ret = avcodec_parameters_to_context(video_context, stream->codecpar);
-if (ret < 0) {
-throw "Failed to copy codec parameters to context";
-}
+        int ret = avcodec_parameters_to_context(video_context, stream->codecpar);
+        if (ret < 0) {
+            throw "Failed to copy codec parameters to context";
+        }
 
-video_context->time_base = (AVRational){ 1, 30 };
-video_context->max_b_frames = 2;
-video_context->gop_size = 12;
-video_context->framerate = (AVRational){ 60, 1 };
+        video_context->time_base = (AVRational){ 1, 30 };
+        video_context->max_b_frames = 2;
+        video_context->gop_size = 12;
+        video_context->framerate = (AVRational){ 60, 1 };
 
-if (stream->codecpar->codec_id == AV_CODEC_ID_H264) {
-av_opt_set(video_context, "preset", "ultrafast", 0);
-} else if (stream->codecpar->codec_id == AV_CODEC_ID_H265) {
-av_opt_set(video_context, "preset", "ultrafast", 0);
-}
+        if (stream->codecpar->codec_id == AV_CODEC_ID_H264) {
+            av_opt_set(video_context, "preset", "ultrafast", 0);
+        } else if (stream->codecpar->codec_id == AV_CODEC_ID_H265) {
+            av_opt_set(video_context, "preset", "ultrafast", 0);
+        }
 
-avcodec_parameters_from_context(stream->codecpar, video_context);
+        avcodec_parameters_from_context(stream->codecpar, video_context);
 
-if ((err = avcodec_open2(video_context, video_codec, NULL)) < 0) {
-throw "Failed to open codec";
-}
+        if ((err = avcodec_open2(video_context, video_codec, NULL)) < 0) {
+            throw "Failed to open codec";
+        }
 
-// AUDIO
-auto audio_codec = avcodec_find_encoder(oformat->audio_codec);
-if (!audio_codec)
-throw "Audio codec not found";
+        // AUDIO
+        auto audio_codec = avcodec_find_encoder(oformat->audio_codec);
+        if (!audio_codec)
+            throw "Audio codec not found";
 
-audio_context = avcodec_alloc_context3(audio_codec);
-if (!audio_context)
-throw "Could not allocate audio codec context";
+        audio_context = avcodec_alloc_context3(audio_codec);
+        if (!audio_context)
+            throw "Could not allocate audio codec context";
 
-audio_context->sample_fmt = AV_SAMPLE_FMT_FLTP;
-if (!check_sample_fmt(audio_codec, audio_context->sample_fmt))
-throw "Encoder does not support FLT planar samples";
+        audio_context->sample_fmt = AV_SAMPLE_FMT_FLTP;
+        if (!check_sample_fmt(audio_codec, audio_context->sample_fmt))
+            throw "Encoder does not support FLT planar samples";
 
-audio_context->sample_rate = 44100;
-audio_context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_MONO;
-audio_context->ch_layout.nb_channels = 1;
+        audio_context->sample_rate = 44100;
+        audio_context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_MONO;
+        audio_context->ch_layout.nb_channels = 1;
 
-ret = avcodec_open2(audio_context, audio_codec, NULL);
-if (ret < 0) {
-throw "Could not open audio codec";
-}
+        ret = avcodec_open2(audio_context, audio_codec, NULL);
+        if (ret < 0) {
+            throw "Could not open audio codec";
+        }
 
-AVStream* audio_stream = avformat_new_stream(ofctx, audio_codec);
-if (!audio_stream) {
-throw "Cannot create audio stream";
-}
+        AVStream* audio_stream = avformat_new_stream(ofctx, audio_codec);
+        if (!audio_stream) {
+            throw "Cannot create audio stream";
+        }
 
-audio_stream->id = 1;
+        audio_stream->id = 1;
 
-audio_stream->time_base = (AVRational){ 1, 44100 };
-avcodec_parameters_from_context(audio_stream->codecpar, audio_context);
+        audio_stream->time_base = (AVRational){ 1, 44100 };
+        avcodec_parameters_from_context(audio_stream->codecpar, audio_context);
 
-audio_frame = av_frame_alloc();
-if (!audio_frame)
-throw "Error allocating an audio frame";
+        audio_frame = av_frame_alloc();
+        if (!audio_frame)
+            throw "Error allocating an audio frame";
 
-audio_frame->format = audio_context->sample_fmt;
-audio_frame->ch_layout = audio_context->ch_layout;
-audio_frame->sample_rate = audio_context->sample_rate;
-audio_frame->nb_samples = 1024; // 44100/60
-err = av_frame_get_buffer(audio_frame, 0);
-if (err < 0) {
-throw "Error allocating an audio buffer";
-}
+        audio_frame->format = audio_context->sample_fmt;
+        audio_frame->ch_layout = audio_context->ch_layout;
+        audio_frame->sample_rate = audio_context->sample_rate;
+        audio_frame->nb_samples = 1024; // 44100/60
+        err = av_frame_get_buffer(audio_frame, 0);
+        if (err < 0) {
+            throw "Error allocating an audio buffer";
+        }
 
-if (sDebug) {
-std::clog << "Line size = " << audio_frame->linesize[0] << "\n";
-std::clog << "Frame size = " << audio_context->frame_size << "\n";
-}
+        if (sDebug) {
+            std::clog << "Line size = " << audio_frame->linesize[0] << "\n";
+            std::clog << "Frame size = " << audio_context->frame_size << "\n";
+        }
 
-if (!(oformat->flags & AVFMT_NOFILE)) {
-if ((err = avio_open(&ofctx->pb, filename.c_str(), AVIO_FLAG_WRITE)) < 0) {
-throw "Failed to open file";
-}
-}
+        if (!(oformat->flags & AVFMT_NOFILE)) {
+            if ((err = avio_open(&ofctx->pb, filename.c_str(), AVIO_FLAG_WRITE)) < 0) {
+                throw "Failed to open file";
+            }
+        }
 
-if ((err = avformat_write_header(ofctx, NULL)) < 0) {
-char buffer[1025];
-av_strerror(err, buffer, 1024);
-std::clog << err << ": " << buffer << "\n";
-throw "Failed to write header";
-}
+        if ((err = avformat_write_header(ofctx, NULL)) < 0) {
+            char buffer[1025];
+            av_strerror(err, buffer, 1024);
+            std::clog << err << ": " << buffer << "\n";
+            throw "Failed to write header";
+        }
 
-av_dump_format(ofctx, 0, filename.c_str(), 1);
-}
+        av_dump_format(ofctx, 0, filename.c_str(), 1);
+    }
 
-~ffmpeg_writer() {
-if (sDebug)
-std::clog << "~ffmpeg_writer()\n";
+    ~ffmpeg_writer() {
+        if (sDebug)
+            std::clog << "~ffmpeg_writer()\n";
 
-// DELAYED FRAMES
-AVPacket pkt;
-av_init_packet(&pkt);
-pkt.data = NULL;
-pkt.size = 0;
+        // DELAYED FRAMES
+        AVPacket pkt;
+        av_init_packet(&pkt);
+        pkt.data = NULL;
+        pkt.size = 0;
 
-for (;;) {
-avcodec_send_frame(video_context, NULL);
-if (avcodec_receive_packet(video_context, &pkt) == 0) {
-av_interleaved_write_frame(ofctx, &pkt);
-av_packet_unref(&pkt);
-} else {
-break;
-}
-}
+        for (;;) {
+            avcodec_send_frame(video_context, NULL);
+            if (avcodec_receive_packet(video_context, &pkt) == 0) {
+                av_interleaved_write_frame(ofctx, &pkt);
+                av_packet_unref(&pkt);
+            } else {
+                break;
+            }
+        }
 
-av_write_trailer(ofctx);
-if (!(oformat->flags & AVFMT_NOFILE)) {
-int err = avio_close(ofctx->pb);
-if (err < 0) {
-std::cout << "Failed to close file: " << err << std::endl;
-}
-}
+        av_write_trailer(ofctx);
+        if (!(oformat->flags & AVFMT_NOFILE)) {
+            int err = avio_close(ofctx->pb);
+            if (err < 0) {
+                std::cout << "Failed to close file: " << err << std::endl;
+            }
+        }
 
-if (videoFrame) {
-av_frame_free(&videoFrame);
-}
-if (audio_frame) {
-av_frame_free(&audio_frame);
-}
-if (video_context) {
-avcodec_free_context(&video_context);
-}
-if (audio_context) {
-avcodec_free_context(&audio_context);
-}
-if (ofctx) {
-avformat_free_context(ofctx);
-}
+        if (videoFrame) {
+            av_frame_free(&videoFrame);
+        }
+        if (audio_frame) {
+            av_frame_free(&audio_frame);
+        }
+        if (video_context) {
+            avcodec_free_context(&video_context);
+        }
+        if (audio_context) {
+            avcodec_free_context(&audio_context);
+        }
+        if (ofctx) {
+            avformat_free_context(ofctx);
+        }
 
-if (sDebug)
-std::clog << "#### End of video stream\n";
-}
+        if (sDebug)
+            std::clog << "#### End of video stream\n";
+    }
 
-virtual void write_frame(const image& img, const sound_frame_t &snd) {
-pushFrame(img, snd);
-}
+    virtual void write_frame(const image& img, const sound_frame_t &snd) {
+        pushFrame(img, snd);
+    }
 };
 
 class gif_writer : public output_writer {
-size_t count_ = 0;
-size_t num_ = 0;
-std::string filename_;
+    size_t count_ = 0;
+    size_t num_ = 0;
+    std::string filename_;
 
 public:
-gif_writer(const std::string filename) : filename_{ filename } {}
+    gif_writer(const std::string filename) : filename_{ filename } {}
 
-virtual void write_frame(const image& img, [[maybe_unused]] const sound_frame_t &snd) {
-if ((count_ % 3) == 0) {
-char buffer[1024];
-sprintf(buffer, "/tmp/gif-%06lu.pgm", num_);
-write_image(buffer, img);
-num_++;
-}
-count_++;
-}
+    virtual void write_frame(const image& img, [[maybe_unused]] const sound_frame_t &snd) {
+        if ((count_ % 3) == 0) {
+            char buffer[1024];
+            sprintf(buffer, "/tmp/gif-%06lu.pgm", num_);
+            write_image(buffer, img);
+            num_++;
+        }
+        count_++;
+    }
 
-~gif_writer() {
-char buffer[1024];
-sprintf(buffer, "convert -delay 5 -loop 0 /tmp/gif-*.pgm '%s'", filename_.c_str());
-std::clog << "GENERATING GIF FILE\n";
-int res = system(buffer);
-if (res != 0) {
-std::cerr << "**** FAILED TO GENERATE GIF FILE (retcode=" << res << ")\n";
-}
-std::clog << "DONE\n";
-delete_files_of_pattern("/tmp/gif-%06d.pgm");
-}
+    ~gif_writer() {
+        char buffer[1024];
+        sprintf(buffer, "convert -delay 5 -loop 0 /tmp/gif-*.pgm '%s'", filename_.c_str());
+        std::clog << "GENERATING GIF FILE\n";
+        int res = system(buffer);
+        if (res != 0) {
+            std::cerr << "**** FAILED TO GENERATE GIF FILE (retcode=" << res << ")\n";
+        }
+        std::clog << "DONE\n";
+        delete_files_of_pattern("/tmp/gif-%06d.pgm");
+    }
 };
 
 std::unique_ptr<output_writer> make_ffmpeg_writer(const std::string &movie_path, size_t w, size_t h) {
-return std::make_unique<ffmpeg_writer>(movie_path, w, h);
+    return std::make_unique<ffmpeg_writer>(movie_path, w, h);
 }
 
 std::unique_ptr<output_writer> make_gif_writer(const std::string &movie_path, [[maybe_unused]] size_t w, [[maybe_unused]] size_t h) {
-return std::make_unique<gif_writer>(movie_path);
+    return std::make_unique<gif_writer>(movie_path);
 }
 
 class null_writer : public output_writer {
 public:
-virtual void write_frame([[maybe_unused]] const image& img, [[maybe_unused]] const sound_frame_t &snd) {}
+    virtual void write_frame([[maybe_unused]] const image& img, [[maybe_unused]] const sound_frame_t &snd) {}
 };
 
 std::unique_ptr<output_writer> make_null_writer() {
-return std::make_unique<null_writer>();
+    return std::make_unique<null_writer>();
 }


### PR DESCRIPTION
This pull request updates MacFlim to be compatible with modern ffmpeg APIs, specifically versions 5 and above. This is a significant change that would drop support for ffmpeg 4. The main changes include:

1. Refactored code for compatibility with ffmpeg 5+ API changes
2. Updated README to recommend ffmpeg 7+, but note compatibility with 5+
3. Various code cleanup/style changes (please feel free to veto any of these; I'd be happy to rework things to better fit your style if desirable)

Benefits:
- Reduce potential compatibility issues for users and developers by using a more widely available and up-to-date version of ffmpeg
- Extend the lifespan, usability, and extensibility of MacFlim

Breaking Changes:
- This update would drop support for ffmpeg 4 and earlier. Users would need to upgrade to ffmpeg 5 or later to compile flimmaker from source.

Testing:
- Tested and verified compilation/use with ffmpeg versions 5.1.6, 6.1.2, and 7.0.2 on:
  * ARM64 (Apple Silicon M1 MacBook Pro running macOS 15.0)
  * x86_64 (AMD-based system running Ubuntu 24.04 LTS)
- Verified successful playback of encoded flims on Macintosh Plus

Thanks for creating MacFlim and releasing it as open source! I've had a lot of fun using it :-)